### PR TITLE
Update install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,17 +59,17 @@ detect_platform_and_arch() {
 
 get_latest_version() {
     # Get latest version from GitHub API, including prereleases
-    API_RESPONSE=$(curl -sS "https://api.github.com/repos/smtg-ai/claude-squad/releases")
+    API_RESPONSE=$(curl -sS "https://github.com/austinamorusoyardstick/claude-squad/releases")
     if [ $? -ne 0 ]; then
         echo "Failed to connect to GitHub API"
         exit 1
     fi
-    
+
     if echo "$API_RESPONSE" | grep -q "Not Found"; then
         echo "No releases found in the repository"
         exit 1
     fi
-    
+
     # Get the first release (latest) from the array
     LATEST_VERSION=$(echo "$API_RESPONSE" | grep -m1 '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed 's/^v//')
     if [ -z "$LATEST_VERSION" ]; then
@@ -89,7 +89,7 @@ download_release() {
     echo "Downloading binary from $binary_url"
     DOWNLOAD_OUTPUT=$(curl -sS -L -f -w '%{http_code}' "$binary_url" -o "${tmp_dir}/${archive_name}" 2>&1)
     HTTP_CODE=$?
-    
+
     if [ $HTTP_CODE -ne 0 ]; then
         echo "Error: Failed to download release asset"
         echo "This could be because:"
@@ -152,7 +152,7 @@ extract_and_install() {
     fi
 
     chmod +x "$bin_dir/$INSTALL_NAME${extension}"
-    
+
     echo ""
     if [ "$UPGRADE_MODE" = true ]; then
         echo "Successfully upgraded '$INSTALL_NAME' to:"
@@ -175,11 +175,11 @@ check_command_exists() {
 
 check_and_install_dependencies() {
     echo "Checking for required dependencies..."
-    
+
     # Check for tmux
     if ! command -v tmux &> /dev/null; then
         echo "tmux is not installed. Installing tmux..."
-        
+
         if [[ "$PLATFORM" == "darwin" ]]; then
             # macOS
             if command -v brew &> /dev/null; then
@@ -208,16 +208,16 @@ check_and_install_dependencies() {
             echo "For Windows, please install tmux via WSL or another method."
             exit 1
         fi
-        
+
         echo "tmux installed successfully."
     else
         echo "tmux is already installed."
     fi
-    
+
     # Check for GitHub CLI (gh)
     if ! command -v gh &> /dev/null; then
         echo "GitHub CLI (gh) is not installed. Installing GitHub CLI..."
-        
+
         if [[ "$PLATFORM" == "darwin" ]]; then
             # macOS
             if command -v brew &> /dev/null; then
@@ -256,20 +256,20 @@ check_and_install_dependencies() {
             echo "Visit https://github.com/cli/cli#installation for installation instructions."
             exit 1
         fi
-        
+
         echo "GitHub CLI (gh) installed successfully."
     else
         echo "GitHub CLI (gh) is already installed."
     fi
-    
+
     echo "All dependencies are installed."
 }
 
 main() {
     # Parse command line arguments
-    INSTALL_NAME="cs"
+    INSTALL_NAME="csa"
     UPGRADE_MODE=false
-    
+
     while [[ $# -gt 0 ]]; do
         case $1 in
             --name)
@@ -286,9 +286,9 @@ main() {
 
     check_command_exists
     detect_platform_and_arch
-    
+
     check_and_install_dependencies
-    
+
     setup_shell_and_path
 
     VERSION=${VERSION:-"latest"}
@@ -296,11 +296,11 @@ main() {
         VERSION=$(get_latest_version)
     fi
 
-    RELEASE_URL="https://github.com/smtg-ai/claude-squad/releases/download/v${VERSION}"
-    ARCHIVE_NAME="claude-squad_${VERSION}_${PLATFORM}_${ARCHITECTURE}${ARCHIVE_EXT}"
+    RELEASE_URL="https://github.com/austinamorusoyardstick/claude-squad/releases/download/V${VERSION}"
+    ARCHIVE_NAME="claude-squad"
     BINARY_URL="${RELEASE_URL}/${ARCHIVE_NAME}"
     TMP_DIR=$(mktemp -d)
-    
+
     download_release "$VERSION" "$BINARY_URL" "$ARCHIVE_NAME" "$TMP_DIR"
     extract_and_install "$TMP_DIR" "$ARCHIVE_NAME" "$BIN_DIR" "$EXTENSION"
 }


### PR DESCRIPTION
This pull request updates the `install.sh` script to reflect changes in repository ownership and modifies naming conventions for installation. The most important changes include updating URLs to point to the new repository, changing the default installation name, and simplifying archive naming conventions.

### Repository URL Updates:
* Updated the GitHub API URL in the `get_latest_version` function to point to the new repository `austinamorusoyardstick/claude-squad`. (`[install.shL62-R62](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL62-R62)`)
* Updated the release URL in the `main` function to use the new repository path. (`[install.shL299-R300](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL299-R300)`)

### Installation Name Changes:
* Changed the default installation name from `cs` to `csa` in the `main` function. (`[install.shL270-R270](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL270-R270)`)

### Archive Naming Simplification:
* Simplified the archive naming convention by removing version, platform, and architecture details from the `ARCHIVE_NAME` variable in the `main` function. (`[install.shL299-R300](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fL299-R300)`)