### PR TITLE
Austinamoruso/rebaes

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -27,6 +27,7 @@ const (
 	KeyExistingBranch // Key for creating instance from existing branch
 	KeyErrorLog // Key for showing error log
 	KeyWebStorm // Key for opening WebStorm
+	KeyRebase // Key for rebasing with main branch
 
 	// Diff keybindings
 	KeyShiftUp
@@ -83,6 +84,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"l":          KeyErrorLog,
 	"w":          KeyWebStorm,
 	"i":          KeyOpenInIDE,
+	"b":          KeyRebase,
 }
 
 // GlobalkeyBindings is a global, immutable map of KeyName tot keybinding.
@@ -202,6 +204,10 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	KeyWebStorm: key.NewBinding(
 		key.WithKeys("w"),
 		key.WithHelp("w", "open WebStorm"),
+	),
+	KeyRebase: key.NewBinding(
+		key.WithKeys("b"),
+		key.WithHelp("b", "rebase"),
 	),
 
 	// -- Special keybindings --

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // runGitCommand executes a git command and returns any error
@@ -140,5 +141,54 @@ func (g *GitWorktree) OpenBranchURL() error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to open branch URL: %w", err)
 	}
+	return nil
+}
+
+// RebaseWithMain rebases the current branch with the main branch
+func (g *GitWorktree) RebaseWithMain() error {
+	// First, create a backup branch
+	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().Unix())
+	if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
+		return fmt.Errorf("failed to create backup branch: %w", err)
+	}
+	
+	// Push the backup branch with --no-verify for speed
+	if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
+		// If push fails, just log it but continue
+		log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
+	}
+	
+	// Fetch the latest from origin
+	if _, err := g.runGitCommand(g.worktreePath, "fetch", "origin"); err != nil {
+		return fmt.Errorf("failed to fetch from origin: %w", err)
+	}
+	
+	// Determine the main branch name by checking remote HEAD
+	mainBranch := "main"
+	remoteHeadOutput, err := g.runGitCommand(g.worktreePath, "symbolic-ref", "refs/remotes/origin/HEAD")
+	if err == nil {
+		// Extract branch name from refs/remotes/origin/main
+		parts := strings.Split(strings.TrimSpace(remoteHeadOutput), "/")
+		if len(parts) > 0 {
+			mainBranch = parts[len(parts)-1]
+		}
+	} else {
+		// Try common defaults
+		if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "origin/main"); err != nil {
+			if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "origin/master"); err == nil {
+				mainBranch = "master"
+			} else if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "origin/dev"); err == nil {
+				mainBranch = "dev"
+			}
+		}
+	}
+	
+	// Perform the rebase
+	if _, err := g.runGitCommand(g.worktreePath, "rebase", fmt.Sprintf("origin/%s", mainBranch)); err != nil {
+		// If rebase fails, try to abort and restore
+		g.runGitCommand(g.worktreePath, "rebase", "--abort")
+		return fmt.Errorf("rebase failed with origin/%s. Backup branch created: %s", mainBranch, backupBranch)
+	}
+	
 	return nil
 }


### PR DESCRIPTION
This pull request introduces a new feature to allow users to rebase their current branch with the main branch directly from the application interface. The changes include adding a new keybinding for the rebase action, implementing the rebase logic in the `GitWorktree` class, and updating the application's key handling logic to support this feature.

### New Feature: Rebase Current Branch with Main Branch

#### Keybinding Updates:
* Added a new keybinding (`KeyRebase`) mapped to the key `b` for initiating the rebase action. This includes updates to `GlobalKeyStringsMap` and `GlobalkeyBindings` in `keys/keys.go`. [[1]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR87) [[2]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR208-R211)

#### Application Logic:
* Updated the `handleKeyPress` method in `app/app.go` to handle the `KeyRebase` action. It checks for uncommitted changes, confirms the action with the user, and triggers the rebase logic.

#### GitWorktree Enhancements:
* Implemented the `RebaseWithMain` method in `session/git/worktree_git.go`. This method performs the following:
  - Creates a unique backup branch before rebasing.
  - Fetches the latest changes from the remote repository.
  - Determines the main branch name dynamically.
  - Executes the rebase operation and handles potential errors.
* Added `time` import to support timestamp generation for unique backup branch names.