### PR TITLE
Austinamoruso/rebase

### DIFF
--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -249,3 +249,38 @@ func (g *GitWorktree) RebaseWithMain() error {
 
 	return nil
 }
+
+// hasMergeConflicts checks if there are currently merge conflicts in the worktree
+func (g *GitWorktree) hasMergeConflicts() bool {
+	// Check git status for conflict markers
+	output, err := g.runGitCommand(g.worktreePath, "status", "--porcelain")
+	if err != nil {
+		return false
+	}
+	
+	// Look for files with conflict status (UU, AA, etc.)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	for _, line := range lines {
+		if len(line) >= 2 {
+			status := line[:2]
+			// Common conflict statuses: UU (both modified), AA (both added), etc.
+			if strings.Contains(status, "U") || status == "AA" || status == "DD" {
+				return true
+			}
+		}
+	}
+	
+	return false
+}
+
+// openWebStormForConflicts opens WebStorm at the worktree path for conflict resolution
+func (g *GitWorktree) openWebStormForConflicts() error {
+	// Open WebStorm at the worktree path
+	cmd := exec.Command("webstorm", g.worktreePath)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to open WebStorm: %w", err)
+	}
+	
+	log.InfoLog.Printf("WebStorm opened for conflict resolution at: %s", g.worktreePath)
+	return nil
+}


### PR DESCRIPTION
This pull request enhances the `GitWorktree` functionality in `session/git/worktree_git.go` by improving rebase error handling, adding new utilities for merge conflict resolution, and providing more control over rebase operations. The key changes include detecting and handling merge conflicts, integrating WebStorm for conflict resolution, and adding methods to manage rebase progress.

### Enhancements to rebase error handling:
- Updated the `RebaseWithMain` method to detect merge conflicts during rebase using the new `hasMergeConflicts` method. If conflicts are detected, WebStorm is opened for resolution, and a detailed error message is returned.

### New utilities for merge conflict resolution:
- Added the `hasMergeConflicts` method to check for merge conflicts by parsing the output of `git status`.
- Introduced the `openWebStormForConflicts` method to launch WebStorm at the worktree path for resolving conflicts.

### Additional methods for rebase management:
- Added the `IsRebaseInProgress` method to check if a rebase is currently in progress by verifying the existence of `.git/rebase-merge` or `.git/rebase-apply` directories.
- Implemented the `ContinueRebase` method to stage resolved files and continue the rebase process