### PR TITLE
Austinamoruso/gitreviewsplit

### DIFF
--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -173,7 +173,7 @@ func (m *home) formatCommentAsPrompt(comment git.PRComment) string {
 		prompt.WriteString("Note: This comment has been split into pieces. Only the following selected pieces are included:\n\n")
 		for i, piece := range acceptedPieces {
 			if i > 0 {
-				prompt.WriteString("\n")
+				prompt.WriteString("\n\n")
 			}
 			prompt.WriteString(piece.Content)
 		}

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -740,14 +740,21 @@ func looksLikeBulletList(lines []string) bool {
 
 // Helper function to check if a line matches numbered list pattern
 func matchesNumberedList(line string) bool {
-	// Match patterns like "1. ", "2) ", etc.
-	if len(line) < 3 {
+	// Match patterns like "1. ", "2) ", "10. ", etc.
+	i := 0
+	for i < len(line) && line[i] >= '0' && line[i] <= '9' {
+		i++
+	}
+
+	// Must have at least one digit.
+	if i == 0 {
 		return false
 	}
-	if line[0] >= '0' && line[0] <= '9' {
-		if line[1] == '.' || line[1] == ')' {
-			return line[2] == ' '
-		}
+
+	// After digits, must have '.' or ')' followed by a space.
+	if i+1 < len(line) && (line[i] == '.' || line[i] == ')') && line[i+1] == ' ' {
+		return true
 	}
+
 	return false
 }

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -621,7 +621,7 @@ func (comment *PRComment) SplitIntoPieces() {
 			var currentPiece strings.Builder
 			pieceIndex := 0
 			
-			for j, line := range lines {
+			for _, line := range lines {
 				trimmedLine := strings.TrimSpace(line)
 				isBullet := trimmedLine != "" && (strings.HasPrefix(trimmedLine, "- ") || 
 					strings.HasPrefix(trimmedLine, "* ") || 

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -617,17 +617,55 @@ func (comment *PRComment) SplitIntoPieces() {
 		// Check if this paragraph contains bullet points
 		lines := strings.Split(para, "\n")
 		if len(lines) > 1 && looksLikeBulletList(lines) {
-			// Split bullet points into individual pieces
+			// Split bullet points into individual pieces, but preserve non-bullet lines
+			var currentPiece strings.Builder
+			pieceIndex := 0
+			
 			for j, line := range lines {
-				line = strings.TrimSpace(line)
-				if line != "" && (strings.HasPrefix(line, "- ") || strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "• ") || matchesNumberedList(line)) {
+				trimmedLine := strings.TrimSpace(line)
+				isBullet := trimmedLine != "" && (strings.HasPrefix(trimmedLine, "- ") || 
+					strings.HasPrefix(trimmedLine, "* ") || 
+					strings.HasPrefix(trimmedLine, "• ") || 
+					matchesNumberedList(trimmedLine))
+				
+				if isBullet {
+					// If we have accumulated non-bullet content, save it as a piece
+					if currentPiece.Len() > 0 {
+						pieces = append(pieces, CommentPiece{
+							ID:       fmt.Sprintf("%d_%d_%d", comment.ID, i, pieceIndex),
+							Content:  strings.TrimSpace(currentPiece.String()),
+							Accepted: comment.Accepted,
+							Original: strings.TrimSpace(currentPiece.String()),
+						})
+						pieceIndex++
+						currentPiece.Reset()
+					}
+					
+					// Add the bullet as its own piece
 					pieces = append(pieces, CommentPiece{
-						ID:       fmt.Sprintf("%d_%d_%d", comment.ID, i, j),
+						ID:       fmt.Sprintf("%d_%d_%d", comment.ID, i, pieceIndex),
 						Content:  line,
-						Accepted: comment.Accepted, // Inherit parent's accepted state
+						Accepted: comment.Accepted,
 						Original: line,
 					})
+					pieceIndex++
+				} else if trimmedLine != "" {
+					// Non-bullet line, accumulate it
+					if currentPiece.Len() > 0 {
+						currentPiece.WriteString("\n")
+					}
+					currentPiece.WriteString(line)
 				}
+			}
+			
+			// Don't forget any trailing non-bullet content
+			if currentPiece.Len() > 0 {
+				pieces = append(pieces, CommentPiece{
+					ID:       fmt.Sprintf("%d_%d_%d", comment.ID, i, pieceIndex),
+					Content:  strings.TrimSpace(currentPiece.String()),
+					Accepted: comment.Accepted,
+					Original: strings.TrimSpace(currentPiece.String()),
+				})
 			}
 		} else {
 			// Keep paragraph as single piece

--- a/ui/pr_comment_split.go
+++ b/ui/pr_comment_split.go
@@ -214,7 +214,8 @@ func (m CommentSplitModel) Update(msg tea.Msg) (CommentSplitModel, tea.Cmd) {
 		case "m":
 			// Merge current piece with next
 			if m.currentIndex < len(m.comment.SplitPieces)-1 {
-				current := m.comment.SplitPieces[m.currentIndex]
+				// Get pointer to modify in place
+				current := &m.comment.SplitPieces[m.currentIndex]
 				next := m.comment.SplitPieces[m.currentIndex+1]
 				
 				// Merge content

--- a/ui/pr_comment_split.go
+++ b/ui/pr_comment_split.go
@@ -1,0 +1,535 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"claude-squad/session/git"
+)
+
+type CommentSplitModel struct {
+	comment       *git.PRComment
+	currentIndex  int
+	width         int
+	height        int
+	showHelp      bool
+	viewport      viewport.Model
+	ready         bool
+	editMode      bool
+	textarea      textarea.Model
+	editingIndex  int
+}
+
+type CommentSplitCompleteMsg struct {
+	Comment *git.PRComment
+}
+
+type CommentSplitCancelMsg struct{}
+
+func NewCommentSplitModel(comment *git.PRComment) CommentSplitModel {
+	// Split the comment into pieces if not already split
+	if !comment.IsSplit {
+		comment.SplitIntoPieces()
+	}
+	
+	return CommentSplitModel{
+		comment:      comment,
+		currentIndex: 0,
+		showHelp:     true,
+		ready:        false,
+		width:        80,
+		height:       24,
+		editMode:     false,
+		editingIndex: -1,
+	}
+}
+
+func (m CommentSplitModel) Init() tea.Cmd {
+	return tea.WindowSize()
+}
+
+func (m CommentSplitModel) Update(msg tea.Msg) (CommentSplitModel, tea.Cmd) {
+	var (
+		cmd  tea.Cmd
+		cmds []tea.Cmd
+	)
+
+	// Handle edit mode first
+	if m.editMode {
+		switch msg := msg.(type) {
+		case tea.KeyMsg:
+			switch msg.String() {
+			case "esc":
+				// Cancel edit mode without saving
+				m.editMode = false
+				m.editingIndex = -1
+				if m.ready {
+					m.updateViewportContent()
+				}
+				return m, nil
+			
+			case "ctrl+s", "enter":
+				// Save the edited content
+				if m.editingIndex >= 0 && m.editingIndex < len(m.comment.SplitPieces) {
+					m.comment.SplitPieces[m.editingIndex].Content = m.textarea.Value()
+				}
+				m.editMode = false
+				m.editingIndex = -1
+				if m.ready {
+					m.updateViewportContent()
+				}
+				return m, nil
+			
+			default:
+				// Pass other keys to textarea
+				m.textarea, cmd = m.textarea.Update(msg)
+				return m, cmd
+			}
+		default:
+			// Pass other messages to textarea
+			m.textarea, cmd = m.textarea.Update(msg)
+			return m, cmd
+		}
+	}
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		
+		headerHeight := 4 // Title + status + blank line
+		footerHeight := 2 // Help text
+		if !m.showHelp {
+			footerHeight = 0
+		}
+		
+		if !m.ready {
+			m.viewport = viewport.New(m.width, m.height-headerHeight-footerHeight)
+			m.viewport.HighPerformanceRendering = false
+			m.ready = true
+			m.viewport.SetYOffset(0)
+		} else {
+			m.viewport.Width = m.width
+			m.viewport.Height = m.height - headerHeight - footerHeight
+		}
+		
+		m.updateViewportContent()
+		m.viewport.SetYOffset(0)
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "q", "esc":
+			return m, func() tea.Msg { return CommentSplitCancelMsg{} }
+		
+		case "?":
+			m.showHelp = !m.showHelp
+			if m.ready {
+				headerHeight := 4
+				footerHeight := 2
+				if !m.showHelp {
+					footerHeight = 0
+				}
+				m.viewport.Height = m.height - headerHeight - footerHeight
+				m.updateViewportContent()
+			}
+			return m, nil
+		
+		case "j", "down":
+			if m.currentIndex < len(m.comment.SplitPieces)-1 {
+				m.currentIndex++
+				if m.ready {
+					m.updateViewportContent()
+					m.ensureCurrentPieceVisible()
+				}
+			}
+			return m, nil
+		
+		case "k", "up":
+			if m.currentIndex > 0 {
+				m.currentIndex--
+				if m.ready {
+					m.updateViewportContent()
+					m.ensureCurrentPieceVisible()
+				}
+			}
+			return m, nil
+		
+		case "a":
+			if len(m.comment.SplitPieces) > 0 {
+				m.comment.SplitPieces[m.currentIndex].Accepted = true
+				if m.ready {
+					m.updateViewportContent()
+				}
+			}
+			return m, nil
+		
+		case "d":
+			if len(m.comment.SplitPieces) > 0 {
+				m.comment.SplitPieces[m.currentIndex].Accepted = false
+				if m.ready {
+					m.updateViewportContent()
+				}
+			}
+			return m, nil
+		
+		case "A":
+			for i := range m.comment.SplitPieces {
+				m.comment.SplitPieces[i].Accepted = true
+			}
+			if m.ready {
+				m.updateViewportContent()
+			}
+			return m, nil
+		
+		case "D":
+			for i := range m.comment.SplitPieces {
+				m.comment.SplitPieces[i].Accepted = false
+			}
+			if m.ready {
+				m.updateViewportContent()
+			}
+			return m, nil
+		
+		case "e":
+			// Enter edit mode for current piece
+			if len(m.comment.SplitPieces) > 0 {
+				m.editMode = true
+				m.editingIndex = m.currentIndex
+				
+				// Initialize textarea with current content
+				ta := textarea.New()
+				ta.SetValue(m.comment.SplitPieces[m.currentIndex].Content)
+				ta.SetWidth(m.width - 4)
+				ta.SetHeight(10)
+				ta.Focus()
+				m.textarea = ta
+			}
+			return m, textarea.Blink
+		
+		case "m":
+			// Merge current piece with next
+			if m.currentIndex < len(m.comment.SplitPieces)-1 {
+				current := m.comment.SplitPieces[m.currentIndex]
+				next := m.comment.SplitPieces[m.currentIndex+1]
+				
+				// Merge content
+				current.Content = current.Content + "\n\n" + next.Content
+				current.Accepted = current.Accepted || next.Accepted // Keep accepted if either was accepted
+				
+				// Remove the next piece
+				m.comment.SplitPieces = append(
+					m.comment.SplitPieces[:m.currentIndex+1],
+					m.comment.SplitPieces[m.currentIndex+2:]...,
+				)
+				
+				if m.ready {
+					m.updateViewportContent()
+				}
+			}
+			return m, nil
+		
+		case "enter":
+			return m, func() tea.Msg { return CommentSplitCompleteMsg{Comment: m.comment} }
+		
+		case "pgup", "shift+up":
+			if m.ready {
+				m.viewport.ViewUp()
+			}
+			return m, nil
+		
+		case "pgdown", "shift+down":
+			if m.ready {
+				m.viewport.ViewDown()
+			}
+			return m, nil
+		
+		case "home", "g":
+			if m.ready {
+				m.viewport.GotoTop()
+			}
+			if len(m.comment.SplitPieces) > 0 {
+				m.currentIndex = 0
+				if m.ready {
+					m.updateViewportContent()
+				}
+			}
+			return m, nil
+		
+		case "end", "G":
+			if m.ready {
+				m.viewport.GotoBottom()
+			}
+			if len(m.comment.SplitPieces) > 0 {
+				m.currentIndex = len(m.comment.SplitPieces) - 1
+				if m.ready {
+					m.updateViewportContent()
+				}
+			}
+			return m, nil
+		}
+	}
+
+	// Handle viewport updates
+	if m.ready && !m.editMode {
+		m.viewport, cmd = m.viewport.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m CommentSplitModel) View() string {
+	if m.editMode {
+		return m.editView()
+	}
+
+	if !m.ready {
+		return m.simpleView()
+	}
+
+	// Build header
+	var header strings.Builder
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("86"))
+
+	header.WriteString(headerStyle.Render("Comment Split Mode"))
+	header.WriteString("\n")
+	
+	// Show comment info
+	infoStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+	header.WriteString(infoStyle.Render(fmt.Sprintf("@%s • %s", m.comment.Author, m.comment.Type)))
+	header.WriteString("\n")
+	
+	// Show piece statistics
+	acceptedCount := 0
+	for _, piece := range m.comment.SplitPieces {
+		if piece.Accepted {
+			acceptedCount++
+		}
+	}
+	
+	statusStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+	header.WriteString(statusStyle.Render(fmt.Sprintf("Pieces: %d/%d • Accepted: %d", 
+		m.currentIndex+1, len(m.comment.SplitPieces), acceptedCount)))
+	header.WriteString("\n")
+
+	// Build footer
+	var footer string
+	if m.showHelp {
+		helpStyle := lipgloss.NewStyle().
+			Foreground(lipgloss.Color("241"))
+		
+		helpItems := []string{
+			"j/k:nav",
+			"a/d:accept/deny",
+			"e:edit",
+			"m:merge",
+			"Enter:done",
+			"q:cancel",
+			"?:help",
+		}
+		footer = "\n" + helpStyle.Render(strings.Join(helpItems, " • "))
+	}
+
+	return header.String() + m.viewport.View() + footer
+}
+
+func (m *CommentSplitModel) updateViewportContent() {
+	var content strings.Builder
+	
+	for i, piece := range m.comment.SplitPieces {
+		if i > 0 {
+			content.WriteString("\n\n")
+		}
+		
+		// Piece box styling
+		var boxStyle lipgloss.Style
+		isSelected := i == m.currentIndex
+		
+		maxWidth := m.width - 4
+		if maxWidth < 40 {
+			maxWidth = 40
+		}
+		
+		if isSelected {
+			boxStyle = lipgloss.NewStyle().
+				BorderStyle(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("86")).
+				Padding(0, 1).
+				Width(maxWidth)
+		} else {
+			boxStyle = lipgloss.NewStyle().
+				BorderStyle(lipgloss.HiddenBorder()).
+				Padding(0, 1).
+				Width(maxWidth)
+		}
+
+		// Status indicator
+		status := "[ ]"
+		if piece.Accepted {
+			status = "[✓]"
+		}
+
+		// Build header
+		header := fmt.Sprintf("%s Piece %d/%d", status, i+1, len(m.comment.SplitPieces))
+		
+		// Show content preview
+		contentPreview := piece.Content
+		if !isSelected && len(contentPreview) > 100 {
+			contentPreview = contentPreview[:97] + "..."
+		}
+		
+		// Wrap text
+		lines := m.wrapText(contentPreview, maxWidth-4)
+		wrappedContent := strings.Join(lines, "\n")
+
+		// Combine header and content
+		pieceContent := fmt.Sprintf("%s\n\n%s",
+			lipgloss.NewStyle().Bold(true).Render(header),
+			wrappedContent)
+
+		// Add selection indicator
+		prefix := "  "
+		if isSelected {
+			prefix = "> "
+		}
+		
+		content.WriteString(prefix + boxStyle.Render(pieceContent))
+	}
+	
+	// Add padding
+	content.WriteString("\n\n\n\n")
+	
+	m.viewport.SetContent(content.String())
+}
+
+func (m *CommentSplitModel) wrapText(text string, width int) []string {
+	if width <= 0 {
+		return []string{text}
+	}
+	
+	var result []string
+	lines := strings.Split(text, "\n")
+	
+	for _, line := range lines {
+		if len(line) <= width {
+			result = append(result, line)
+			continue
+		}
+		
+		// Wrap long lines
+		for len(line) > width {
+			// Find last space before width
+			lastSpace := width
+			for i := width; i > 0; i-- {
+				if line[i-1] == ' ' {
+					lastSpace = i
+					break
+				}
+			}
+			
+			// If no space found, just cut at width
+			if lastSpace == width {
+				result = append(result, line[:width])
+				line = line[width:]
+			} else {
+				result = append(result, line[:lastSpace-1])
+				line = line[lastSpace:]
+			}
+		}
+		
+		if len(line) > 0 {
+			result = append(result, line)
+		}
+	}
+	
+	return result
+}
+
+func (m *CommentSplitModel) ensureCurrentPieceVisible() {
+	// Simple implementation - could be improved
+	lines := strings.Split(m.viewport.View(), "\n")
+	totalLines := len(lines)
+	
+	if totalLines == 0 {
+		return
+	}
+	
+	// Estimate position based on piece index
+	estimatedPosition := float64(m.currentIndex) / float64(len(m.comment.SplitPieces))
+	targetLine := int(estimatedPosition * float64(m.viewport.TotalLineCount()))
+	
+	// Scroll to make the piece visible
+	if targetLine < m.viewport.YOffset {
+		m.viewport.SetYOffset(targetLine)
+	} else if targetLine > m.viewport.YOffset+m.viewport.Height-5 {
+		m.viewport.SetYOffset(targetLine - m.viewport.Height + 5)
+	}
+}
+
+func (m CommentSplitModel) simpleView() string {
+	var b strings.Builder
+	
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("86"))
+	
+	b.WriteString(headerStyle.Render("Comment Split Mode"))
+	b.WriteString("\n\n")
+	
+	// Show current piece
+	if len(m.comment.SplitPieces) > 0 && m.currentIndex < len(m.comment.SplitPieces) {
+		piece := m.comment.SplitPieces[m.currentIndex]
+		
+		status := "[ ]"
+		if piece.Accepted {
+			status = "[✓]"
+		}
+		
+		b.WriteString(fmt.Sprintf("Piece %d/%d:\n", m.currentIndex+1, len(m.comment.SplitPieces)))
+		b.WriteString(fmt.Sprintf("%s\n\n", status))
+		
+		content := piece.Content
+		if len(content) > 300 {
+			content = content[:297] + "..."
+		}
+		b.WriteString(content)
+		b.WriteString("\n\n")
+	}
+	
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+	
+	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:edit • Enter:done • q:cancel"))
+	
+	return b.String()
+}
+
+func (m CommentSplitModel) editView() string {
+	var b strings.Builder
+	
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("86"))
+	
+	b.WriteString(headerStyle.Render("Edit Piece"))
+	b.WriteString("\n\n")
+	
+	b.WriteString(m.textarea.View())
+	b.WriteString("\n\n")
+	
+	helpStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+	
+	b.WriteString(helpStyle.Render("Ctrl+S/Enter: Save • Esc: Cancel"))
+	
+	return b.String()
+}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -586,7 +586,17 @@ func (m PRReviewModel) simpleView() string {
 		comment := m.pr.Comments[m.currentIndex]
 		
 		status := "[ ]"
-		if comment.Accepted {
+		if comment.IsSplit {
+			acceptedCount := 0
+			for _, piece := range comment.SplitPieces {
+				if piece.Accepted {
+					acceptedCount++
+				}
+			}
+			if acceptedCount > 0 {
+				status = fmt.Sprintf("[%d/%d]", acceptedCount, len(comment.SplitPieces))
+			}
+		} else if comment.Accepted {
 			status = "[✓]"
 		}
 		


### PR DESCRIPTION
This pull request introduces a new feature that allows splitting PR comments into smaller pieces for more granular review and processing. The changes include updates to handle split comments in both the backend logic and the user interface. The most important changes are grouped below by theme.

### Backend Enhancements for Split Comments:

* Added support for splitting comments into logical pieces (`SplitPieces`) and tracking whether a comment is split (`IsSplit`). Introduced the `CommentPiece` struct to represent individual pieces. (`session/git/pr_comments.go`, [session/git/pr_comments.goR30-R38](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32R30-R38))
* Implemented methods for splitting (`SplitIntoPieces`), merging (`MergePieces`), and retrieving accepted pieces (`GetAcceptedPieces`) of a comment. These methods ensure only accepted pieces are included in prompts and processing. (`session/git/pr_comments.go`, [session/git/pr_comments.goR557-R674](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32R557-R674))
* Modified `GetAcceptedComments` to include split comments only if they have at least one accepted piece. (`session/git/pr_comments.go`, [session/git/pr_comments.goL414-R435](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32L414-R435))

### UI Updates for Split Comment Support:

* Added a new "split mode" to the `PRReviewModel`, allowing users to split comments into pieces and accept or reject individual pieces. This includes handling split mode updates and rendering the split view. (`ui/pr_review.go`, [[1]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR22-R23) [[2]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR54-R81) [[3]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR256-R260)
* Updated the viewport and simple view to display the acceptance status of split comments (e.g., `[2/3]` for 2 out of 3 pieces accepted). (`ui/pr_review.go`, [[1]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eL330-R386) [[2]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eL509-R575)

### Prompt Formatting and Processing:

* Updated `formatCommentAsPrompt` to include only accepted pieces of split comments. If no pieces are accepted, the prompt is skipped. (`app/pr_processor.go`, [app/pr_processor.goR163-R183](diffhunk://#diff-6798adbdeafaeecb0b2618b1e68ba4cb9f69b4e486dbd5dbc0e4eea5de0611b6R163-R183))
* Enhanced `processCommentsSequentially` to handle split comments by including the count of selected pieces in test messages. (`app/pr_processor.go`, [app/pr_processor.goR84-R87](diffhunk://#diff-6798adbdeafaeecb0b2618b1e68ba4cb9f69b4e486dbd5dbc0e4eea5de0611b6R84-R87))

These changes collectively improve the flexibility and granularity of PR comment processing, enabling users to focus on relevant portions of split comments during reviews.