### PR TITLE
Austinamoruso/gitreviewfilteronoff

### DIFF
--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -108,7 +108,7 @@ func (m *home) processCommentsSequentially(comments []*git.PRComment) tea.Cmd {
 	}
 }
 
-func (m *home) sendCommentToClaude(comment git.PRComment) error {
+func (m *home) sendCommentToClaude(comment *git.PRComment) error {
 	selected := m.list.GetSelectedInstance()
 	if selected == nil {
 		return fmt.Errorf("no instance selected")

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -50,7 +50,7 @@ func (m *home) processAcceptedComments(comments []*git.PRComment) tea.Cmd {
 	return m.processCommentsSequentially(comments)
 }
 
-func (m *home) processCommentsSequentially(comments []git.PRComment) tea.Cmd {
+func (m *home) processCommentsSequentially(comments []*git.PRComment) tea.Cmd {
 	return func() tea.Msg {
 		selected := m.list.GetSelectedInstance()
 		if selected == nil {

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -121,7 +121,7 @@ func (m *home) sendCommentToClaude(comment git.PRComment) error {
 	return selected.SendPrompt(prompt)
 }
 
-func (m *home) formatCommentAsPrompt(comment git.PRComment) string {
+func (m *home) formatCommentAsPrompt(comment *git.PRComment) string {
 	var prompt strings.Builder
 	
 	// Format header based on comment type

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -26,7 +26,7 @@ type commentProcessedMsg struct {
 
 type allCommentsProcessedMsg struct{}
 
-func (m *home) processAcceptedComments(comments []git.PRComment) tea.Cmd {
+func (m *home) processAcceptedComments(comments []*git.PRComment) tea.Cmd {
 	// First show the processing overlay
 	progressText := fmt.Sprintf("Processing %d PR comments...\n\n", len(comments))
 	for i, comment := range comments {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -60,8 +60,8 @@ type PullRequest struct {
 	BaseRef     string `json:"baseRef"`
 	URL         string `json:"url"`
 	HeadSHA     string `json:"headSHA"`
-	Comments    []PRComment // Filtered comments (default view)
-	AllComments []PRComment // All comments including outdated/resolved
+	Comments    []*PRComment // Filtered comments (default view)
+	AllComments []*PRComment // All comments including outdated/resolved
 	Reviews     []PRReview
 }
 

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -418,7 +418,7 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 			IsResolved: false,
 			Accepted:   false,
 		}
-		pr.Comments = append(pr.Comments, comment)
+		pr.AllComments = append(pr.AllComments, comment)
 	}
 
 	return nil

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -407,7 +407,7 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 			return fmt.Errorf("failed to parse updatedAt for issue comment ID %d: %w", ic.ID, err)
 		}
 		
-		comment := PRComment{
+		comment := &PRComment{
 			ID:         ic.ID,
 			Body:       ic.Body,
 			Author:     ic.User.Login,

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -134,7 +134,7 @@ func (pr *PullRequest) FetchComments(workingDir string) error {
 	filteredComments := make([]*PRComment, 0, len(pr.AllComments))
 	for _, comment := range pr.AllComments {
 		// Filter out outdated, resolved, and gemini review comments
-		if !comment.IsOutdated && !comment.IsResolved && !strings.Contains(comment.Body, "/gemini review") {
+		if !comment.IsOutdated && !comment.IsResolved && !comment.IsGeminiReview {
 			filteredComments = append(filteredComments, comment)
 		}
 	}

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -426,7 +426,8 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 
 func (pr *PullRequest) GetAcceptedComments() []PRComment {
 	accepted := []PRComment{}
-	for _, comment := range pr.Comments {
+	// Check both filtered and all comments since accepted state can be set on either
+	for _, comment := range pr.AllComments {
 		if comment.IsSplit {
 			// For split comments, only include if at least one piece is accepted
 			hasAcceptedPiece := false
@@ -623,14 +624,14 @@ func (comment *PRComment) SplitIntoPieces() {
 			// Split bullet points into individual pieces, but preserve non-bullet lines
 			var currentPiece strings.Builder
 			pieceIndex := 0
-			
+
 			for _, line := range lines {
 				trimmedLine := strings.TrimSpace(line)
-				isBullet := trimmedLine != "" && (strings.HasPrefix(trimmedLine, "- ") || 
-					strings.HasPrefix(trimmedLine, "* ") || 
-					strings.HasPrefix(trimmedLine, "• ") || 
+				isBullet := trimmedLine != "" && (strings.HasPrefix(trimmedLine, "- ") ||
+					strings.HasPrefix(trimmedLine, "* ") ||
+					strings.HasPrefix(trimmedLine, "• ") ||
 					matchesNumberedList(trimmedLine))
-				
+
 				if isBullet {
 					// If we have accumulated non-bullet content, save it as a piece
 					if currentPiece.Len() > 0 {
@@ -643,7 +644,7 @@ func (comment *PRComment) SplitIntoPieces() {
 						pieceIndex++
 						currentPiece.Reset()
 					}
-					
+
 					// Add the bullet as its own piece
 					pieces = append(pieces, CommentPiece{
 						ID:       fmt.Sprintf("%d_%d_%d", comment.ID, i, pieceIndex),
@@ -660,7 +661,7 @@ func (comment *PRComment) SplitIntoPieces() {
 					currentPiece.WriteString(line)
 				}
 			}
-			
+
 			// Don't forget any trailing non-bullet content
 			if currentPiece.Len() > 0 {
 				pieces = append(pieces, CommentPiece{

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -289,7 +289,7 @@ func (pr *PullRequest) fetchReviews(workingDir string) error {
 			PullRequestReviewID: r.ID,
 			IsOutdated:         isOutdated,
 			IsResolved:         r.State == "DISMISSED",
-			IsGeminiReview:     strings.Contains(r.Body, "/gemini review"),
+			IsGeminiReview:     strings.Contains(r.Body, GeminiReviewCommand),
 			Accepted:           false,
 		}
 		pr.AllComments = append(pr.AllComments, reviewComment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -483,9 +483,31 @@ func stripMarkdownSimple(content string) string {
 	return content
 }
 
-// GetCommentStats returns statistics about the comments (includes both shown and filtered)
+// GetCommentStats returns statistics about the filtered comments
 func (pr *PullRequest) GetCommentStats() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
 	for _, comment := range pr.Comments {
+		total++
+		if comment.IsOutdated {
+			outdated++
+		}
+		if comment.IsResolved {
+			resolved++
+		}
+		switch comment.Type {
+		case "review":
+			reviews++
+		case "review_comment":
+			reviewComments++
+		case "issue_comment":
+			issueComments++
+		}
+	}
+	return
+}
+
+// GetStatsForAllComments returns statistics about all comments (including outdated/resolved)
+func (pr *PullRequest) GetStatsForAllComments() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
+	for _, comment := range pr.AllComments {
 		total++
 		if comment.IsOutdated {
 			outdated++

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -372,7 +372,7 @@ func (pr *PullRequest) fetchReviewComments(workingDir string, resolvedMap map[in
 			PullRequestReviewID: rc.PullRequestReviewID,
 			IsOutdated:         isOutdated,
 			IsResolved:         isResolved,
-			IsGeminiReview:     strings.Contains(rc.Body, "/gemini review"),
+			IsGeminiReview:     strings.Contains(rc.Body, GeminiReviewCommand),
 			Accepted:           false,
 		}
 		pr.AllComments = append(pr.AllComments, comment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -284,6 +284,7 @@ func (pr *PullRequest) fetchReviews(workingDir string) error {
 			PullRequestReviewID: r.ID,
 			IsOutdated:         isOutdated,
 			IsResolved:         r.State == "DISMISSED",
+			IsGeminiReview:     strings.Contains(r.Body, "/gemini review"),
 			Accepted:           false,
 		}
 		pr.AllComments = append(pr.AllComments, reviewComment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -346,7 +346,7 @@ func (pr *PullRequest) fetchReviewComments(workingDir string, resolvedMap map[in
 			line = *rc.Line
 		}
 
-		comment := PRComment{
+		comment := &PRComment{
 			ID:                 rc.ID,
 			Body:               rc.Body,
 			Path:               rc.Path,

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -425,8 +425,8 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 	return nil
 }
 
-func (pr *PullRequest) GetAcceptedComments() []PRComment {
-	accepted := []PRComment{}
+func (pr *PullRequest) GetAcceptedComments() []*PRComment {
+	accepted := []*PRComment{}
 	// Check both filtered and all comments since accepted state can be set on either
 	for _, comment := range pr.AllComments {
 		if comment.IsSplit {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -340,11 +340,6 @@ func (pr *PullRequest) fetchReviewComments(workingDir string, resolvedMap map[in
 		// Check if comment is resolved using the resolved map
 		isResolved := resolvedMap[rc.ID]
 
-		// Skip outdated or resolved comments
-		if isOutdated || isResolved {
-			continue
-		}
-
 		line := 0
 		if rc.Line != nil {
 			line = *rc.Line
@@ -370,7 +365,7 @@ func (pr *PullRequest) fetchReviewComments(workingDir string, resolvedMap map[in
 			IsResolved:         isResolved,
 			Accepted:           false,
 		}
-		pr.Comments = append(pr.Comments, comment)
+		pr.AllComments = append(pr.AllComments, comment)
 	}
 
 	return nil

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -491,7 +491,7 @@ func stripMarkdownSimple(content string) string {
 }
 
 // getCommentStats is a private helper that calculates stats for a given slice of comments
-func getCommentStats(comments []*PRComment) (total, reviews, reviewComments, issueComments, outdated, resolved int) {
+func getCommentStats(comments []*PRComment) (total, reviews, reviewComments, issueComments, outdated, resolved, geminiReviews int) {
 	for _, comment := range comments {
 		total++
 		if comment.IsOutdated {
@@ -499,6 +499,9 @@ func getCommentStats(comments []*PRComment) (total, reviews, reviewComments, iss
 		}
 		if comment.IsResolved {
 			resolved++
+		}
+		if comment.IsGeminiReview {
+			geminiReviews++
 		}
 		switch comment.Type {
 		case "review":

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -582,8 +582,8 @@ func (pr *PullRequest) GetAllCommentStats(workingDir string) (total, shown, outd
 }
 
 // GetFilteredComments returns comments that are not outdated or resolved
-func (pr *PullRequest) GetFilteredComments() []PRComment {
-	filtered := []PRComment{}
+func (pr *PullRequest) GetFilteredComments() []*PRComment {
+	filtered := []*PRComment{}
 	for _, comment := range pr.Comments {
 		if !comment.IsOutdated && !comment.IsResolved {
 			filtered = append(filtered, comment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -132,7 +132,8 @@ func (pr *PullRequest) FetchComments(workingDir string) error {
 	// After fetching all comments, separate filtered from all
 	filteredComments := make([]*PRComment, 0, len(pr.AllComments))
 	for _, comment := range pr.AllComments {
-		if !comment.IsOutdated && !comment.IsResolved {
+		// Filter out outdated, resolved, and gemini review comments
+		if !comment.IsOutdated && !comment.IsResolved && !strings.Contains(comment.Body, "/gemini review") {
 			filteredComments = append(filteredComments, comment)
 		}
 	}

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -102,8 +102,8 @@ func GetCurrentPR(workingDir string) (*PullRequest, error) {
 
 func (pr *PullRequest) FetchComments(workingDir string) error {
 	// Always clear existing data to ensure fresh fetch
-	pr.Comments = []PRComment{}
-	pr.AllComments = []PRComment{}
+	pr.Comments = []*PRComment{}
+	pr.AllComments = []*PRComment{}
 	pr.Reviews = []PRReview{}
 
 	// First fetch resolved status for review threads

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -27,6 +27,7 @@ type PRComment struct {
 	PullRequestReviewID int      `json:"pull_request_review_id"`
 	IsOutdated         bool      `json:"is_outdated"`
 	IsResolved         bool      `json:"is_resolved"`
+	IsGeminiReview     bool      `json:"is_gemini_review"`
 	Accepted           bool      `json:"-"`
 	// Cached rendered content
 	RenderedBody       string    `json:"-"`

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -130,11 +130,13 @@ func (pr *PullRequest) FetchComments(workingDir string) error {
 	}
 
 	// After fetching all comments, separate filtered from all
+	filteredComments := make([]*PRComment, 0, len(pr.AllComments))
 	for _, comment := range pr.AllComments {
 		if !comment.IsOutdated && !comment.IsResolved {
-			pr.Comments = append(pr.Comments, comment)
+			filteredComments = append(filteredComments, comment)
 		}
 	}
+	pr.Comments = filteredComments
 
 	return nil
 }

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -485,9 +485,9 @@ func stripMarkdownSimple(content string) string {
 	return content
 }
 
-// GetCommentStats returns statistics about the filtered comments
-func (pr *PullRequest) GetCommentStats() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
-	for _, comment := range pr.Comments {
+// getCommentStats is a private helper that calculates stats for a given slice of comments
+func getCommentStats(comments []*PRComment) (total, reviews, reviewComments, issueComments, outdated, resolved int) {
+	for _, comment := range comments {
 		total++
 		if comment.IsOutdated {
 			outdated++
@@ -507,26 +507,14 @@ func (pr *PullRequest) GetCommentStats() (total, reviews, reviewComments, issueC
 	return
 }
 
+// GetCommentStats returns statistics about the filtered comments
+func (pr *PullRequest) GetCommentStats() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
+	return getCommentStats(pr.Comments)
+}
+
 // GetStatsForAllComments returns statistics about all comments (including outdated/resolved)
 func (pr *PullRequest) GetStatsForAllComments() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
-	for _, comment := range pr.AllComments {
-		total++
-		if comment.IsOutdated {
-			outdated++
-		}
-		if comment.IsResolved {
-			resolved++
-		}
-		switch comment.Type {
-		case "review":
-			reviews++
-		case "review_comment":
-			reviewComments++
-		case "issue_comment":
-			issueComments++
-		}
-	}
-	return
+	return getCommentStats(pr.AllComments)
 }
 
 // GetAllCommentStats returns statistics about all comments including filtered ones

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -130,7 +130,6 @@ func (pr *PullRequest) FetchComments(workingDir string) error {
 	}
 
 	// After fetching all comments, separate filtered from all
-	pr.Comments = []PRComment{}
 	for _, comment := range pr.AllComments {
 		if !comment.IsOutdated && !comment.IsResolved {
 			pr.Comments = append(pr.Comments, comment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -426,7 +426,7 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 			Type:           "issue_comment",
 			IsOutdated:     false, // Issue comments are never outdated
 			IsResolved:     false,
-			IsGeminiReview: strings.Contains(ic.Body, "/gemini review"),
+			IsGeminiReview: strings.Contains(ic.Body, GeminiReviewCommand),
 			Accepted:       false,
 		}
 		pr.AllComments = append(pr.AllComments, comment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -412,16 +412,17 @@ func (pr *PullRequest) fetchIssueComments(workingDir string) error {
 		}
 		
 		comment := &PRComment{
-			ID:         ic.ID,
-			Body:       ic.Body,
-			Author:     ic.User.Login,
-			CreatedAt:  createdAt,
-			UpdatedAt:  updatedAt,
-			State:      "pending",
-			Type:       "issue_comment",
-			IsOutdated: false, // Issue comments are never outdated
-			IsResolved: false,
-			Accepted:   false,
+			ID:             ic.ID,
+			Body:           ic.Body,
+			Author:         ic.User.Login,
+			CreatedAt:      createdAt,
+			UpdatedAt:      updatedAt,
+			State:          "pending",
+			Type:           "issue_comment",
+			IsOutdated:     false, // Issue comments are never outdated
+			IsResolved:     false,
+			IsGeminiReview: strings.Contains(ic.Body, "/gemini review"),
+			Accepted:       false,
 		}
 		pr.AllComments = append(pr.AllComments, comment)
 	}

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+const (
+	// GeminiReviewCommand is the command string used to identify Gemini review comments
+	GeminiReviewCommand = "/gemini review"
+)
+
 type PRComment struct {
 	ID                 int       `json:"id"`
 	Body               string    `json:"body"`

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -270,7 +270,7 @@ func (pr *PullRequest) fetchReviews(workingDir string) error {
 		}
 
 		// Convert review to comment format
-		reviewComment := PRComment{
+		reviewComment := &PRComment{
 			ID:                 r.ID,
 			Body:               r.Body,
 			Author:             r.User.Login,

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -367,6 +367,7 @@ func (pr *PullRequest) fetchReviewComments(workingDir string, resolvedMap map[in
 			PullRequestReviewID: rc.PullRequestReviewID,
 			IsOutdated:         isOutdated,
 			IsResolved:         isResolved,
+			IsGeminiReview:     strings.Contains(rc.Body, "/gemini review"),
 			Accepted:           false,
 		}
 		pr.AllComments = append(pr.AllComments, comment)

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -517,11 +517,18 @@ func getCommentStats(comments []*PRComment) (total, reviews, reviewComments, iss
 
 // GetCommentStats returns statistics about the filtered comments
 func (pr *PullRequest) GetCommentStats() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
-	return getCommentStats(pr.Comments)
+	total, reviews, reviewComments, issueComments, outdated, resolved, _ = getCommentStats(pr.Comments)
+	return
 }
 
 // GetStatsForAllComments returns statistics about all comments (including outdated/resolved)
 func (pr *PullRequest) GetStatsForAllComments() (total, reviews, reviewComments, issueComments, outdated, resolved int) {
+	total, reviews, reviewComments, issueComments, outdated, resolved, _ = getCommentStats(pr.AllComments)
+	return
+}
+
+// GetStatsForAllCommentsWithGemini returns statistics about all comments including gemini review count
+func (pr *PullRequest) GetStatsForAllCommentsWithGemini() (total, reviews, reviewComments, issueComments, outdated, resolved, geminiReviews int) {
 	return getCommentStats(pr.AllComments)
 }
 

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -350,7 +350,6 @@ func (m PRReviewModel) View() string {
 		return m.splitModel.View()
 	}
 
-	if len(m.pr.Comments) == 0 {
 	comments := m.getActiveComments()
 	if len(comments) == 0 {
 		if m.filterEnabled && len(m.pr.AllComments) > 0 {

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -191,45 +191,21 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			}
 			return m, nil
 		
-		case "A":
-			// Accept all comments in the current view
+		case "A", "D":
+			isAcceptAll := msg.String() == "A"
 			comments := m.getActiveComments()
 			for _, comment := range comments {
 				// Update in AllComments
 				for i := range m.pr.AllComments {
 					if m.pr.AllComments[i].ID == comment.ID {
-						m.pr.AllComments[i].Accepted = true
+						m.pr.AllComments[i].Accepted = isAcceptAll
 						break
 					}
 				}
 				// Update in filtered comments if applicable
 				for i := range m.pr.Comments {
 					if m.pr.Comments[i].ID == comment.ID {
-						m.pr.Comments[i].Accepted = true
-						break
-					}
-				}
-			}
-			if m.ready {
-				m.updateViewportContent()
-			}
-			return m, nil
-		
-		case "D":
-			// Deny all comments in the current view
-			comments := m.getActiveComments()
-			for _, comment := range comments {
-				// Update in AllComments
-				for i := range m.pr.AllComments {
-					if m.pr.AllComments[i].ID == comment.ID {
-						m.pr.AllComments[i].Accepted = false
-						break
-					}
-				}
-				// Update in filtered comments if applicable
-				for i := range m.pr.Comments {
-					if m.pr.Comments[i].ID == comment.ID {
-						m.pr.Comments[i].Accepted = false
+						m.pr.Comments[i].Accepted = isAcceptAll
 						break
 					}
 				}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -199,8 +199,9 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 
 		case "s":
 			// Enter split mode for current comment
-			if len(m.pr.Comments) > 0 && !m.splitMode {
-				splitModel := NewCommentSplitModel(&m.pr.Comments[m.currentIndex])
+			comments := m.getActiveComments()
+			if len(comments) > 0 && !m.splitMode && m.currentIndex < len(comments) {
+				splitModel := NewCommentSplitModel(comments[m.currentIndex])
 				m.splitModel = &splitModel
 				m.splitMode = true
 				return m, m.splitModel.Init()

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -286,7 +286,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 }
 
 // getActiveComments returns the comments based on filter state
-func (m *PRReviewModel) getActiveComments() []git.PRComment {
+func (m PRReviewModel) getActiveComments() []*git.PRComment {
 	if m.filterEnabled {
 		return m.pr.Comments
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -417,7 +417,7 @@ func (m PRReviewModel) View() string {
 	if m.filterEnabled {
 		total, reviews, reviewComments, issueComments, _, _ := m.pr.GetCommentStats()
 		header.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%dR %dRC %dG), %d accepted | %d/%d%s", 
-			total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(comments), scrollInfo)))
+			total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	} else {
 		// Count stats from all comments
 		var total, reviews, reviewComments, issueComments, outdated, resolved int
@@ -439,7 +439,7 @@ func (m PRReviewModel) View() string {
 			}
 		}
 		header.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%dR %dRC %dG, %d outdated, %d resolved), %d accepted | %d/%d%s", 
-			total, reviews, reviewComments, issueComments, outdated, resolved, acceptedCount, m.currentIndex+1, len(comments), scrollInfo)))
+			total, reviews, reviewComments, issueComments, outdated, resolved, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	}
 	header.WriteString("\n") // Single newline after status
 

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -189,9 +189,10 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 
 		case "e":
-			if len(m.pr.Comments) > 0 && m.currentIndex < len(m.pr.Comments) {
+			comments := m.getActiveComments()
+			if len(comments) > 0 && m.currentIndex < len(comments) {
 				return m, func() tea.Msg {
-					return PRReviewShowCommentMsg{Comment: &m.pr.Comments[m.currentIndex]}
+					return PRReviewShowCommentMsg{Comment: comments[m.currentIndex]}
 				}
 			}
 			return m, nil

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -25,7 +25,7 @@ type PRReviewModel struct {
 }
 
 type PRReviewCompleteMsg struct {
-	AcceptedComments []git.PRComment
+	AcceptedComments []*git.PRComment
 }
 
 type PRReviewCancelMsg struct{}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -166,45 +166,22 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			}
 			return m, nil
 		
-		case "a":
+		case "a", "d":
+			isAccept := msg.String() == "a"
 			comments := m.getActiveComments()
 			if len(comments) > 0 && m.currentIndex < len(comments) {
-				// Find and update the comment in AllComments
 				targetID := comments[m.currentIndex].ID
+				// Find and update the comment in AllComments
 				for i := range m.pr.AllComments {
 					if m.pr.AllComments[i].ID == targetID {
-						m.pr.AllComments[i].Accepted = true
+						m.pr.AllComments[i].Accepted = isAccept
 						break
 					}
 				}
 				// Also update in filtered comments if applicable
 				for i := range m.pr.Comments {
 					if m.pr.Comments[i].ID == targetID {
-						m.pr.Comments[i].Accepted = true
-						break
-					}
-				}
-				if m.ready {
-					m.updateViewportContent()
-				}
-			}
-			return m, nil
-		
-		case "d":
-			comments := m.getActiveComments()
-			if len(comments) > 0 && m.currentIndex < len(comments) {
-				// Find and update the comment in AllComments
-				targetID := comments[m.currentIndex].ID
-				for i := range m.pr.AllComments {
-					if m.pr.AllComments[i].ID == targetID {
-						m.pr.AllComments[i].Accepted = false
-						break
-					}
-				}
-				// Also update in filtered comments if applicable
-				for i := range m.pr.Comments {
-					if m.pr.Comments[i].ID == targetID {
-						m.pr.Comments[i].Accepted = false
+						m.pr.Comments[i].Accepted = isAccept
 						break
 					}
 				}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -372,24 +372,7 @@ func (m PRReviewModel) View() string {
 			total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	} else {
 		// Count stats from all comments
-		var total, reviews, reviewComments, issueComments, outdated, resolved int
-		for _, comment := range m.pr.AllComments {
-			total++
-			if comment.IsOutdated {
-				outdated++
-			}
-			if comment.IsResolved {
-				resolved++
-			}
-			switch comment.Type {
-			case "review":
-				reviews++
-			case "review_comment":
-				reviewComments++
-			case "issue_comment":
-				issueComments++
-			}
-		}
+		total, reviews, reviewComments, issueComments, outdated, resolved := m.pr.GetStatsForAllComments()
 		header.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%dR %dRC %dG, %d outdated, %d resolved), %d accepted | %d/%d%s", 
 			total, reviews, reviewComments, issueComments, outdated, resolved, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -314,7 +314,7 @@ func (m PRReviewModel) View() string {
 		Foreground(lipgloss.Color("28")).
 		Italic(true)
 	if m.filterEnabled {
-		header.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved)"))
+		header.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved/gemini)"))
 	} else {
 		header.WriteString(filterStyle.Render("(Filter: OFF - showing all comments)"))
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -416,7 +416,8 @@ func (m PRReviewModel) View() string {
 func (m *PRReviewModel) updateViewportContent() {
 	var content strings.Builder
 	
-	for i, comment := range m.pr.Comments {
+	comments := m.getActiveComments()
+	for i, comment := range comments {
 		if i > 0 {
 			content.WriteString("\n\n") // Add consistent spacing between comments
 		}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -170,21 +170,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			isAccept := msg.String() == "a"
 			comments := m.getActiveComments()
 			if len(comments) > 0 && m.currentIndex < len(comments) {
-				targetID := comments[m.currentIndex].ID
-				// Find and update the comment in AllComments
-				for i := range m.pr.AllComments {
-					if m.pr.AllComments[i].ID == targetID {
-						m.pr.AllComments[i].Accepted = isAccept
-						break
-					}
-				}
-				// Also update in filtered comments if applicable
-				for i := range m.pr.Comments {
-					if m.pr.Comments[i].ID == targetID {
-						m.pr.Comments[i].Accepted = isAccept
-						break
-					}
-				}
+				comments[m.currentIndex].Accepted = isAccept
 				if m.ready {
 					m.updateViewportContent()
 				}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -585,7 +585,8 @@ func (m *PRReviewModel) ensureCurrentCommentVisible() {
 	}
 	
 	// Estimate position based on comment index
-	estimatedPosition := float64(m.currentIndex) / float64(len(m.pr.Comments))
+	comments := m.getActiveComments()
+	estimatedPosition := float64(m.currentIndex) / float64(len(comments))
 	targetLine := int(estimatedPosition * float64(m.viewport.TotalLineCount()))
 	
 	// Scroll to make the comment visible

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -550,6 +550,9 @@ func (m *PRReviewModel) ensureCurrentCommentVisible() {
 	
 	// Estimate position based on comment index
 	comments := m.getActiveComments()
+	if len(comments) == 0 {
+		return
+	}
 	estimatedPosition := float64(m.currentIndex) / float64(len(comments))
 	targetLine := int(estimatedPosition * float64(m.viewport.TotalLineCount()))
 	

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -618,15 +618,19 @@ func (m PRReviewModel) simpleView() string {
 			b.WriteString("\n")
 		}
 	} else {
-		// Count stats from all comments
-		total, reviews, reviewComments, issueComments, outdated, resolved := m.pr.GetStatsForAllComments()
+		// Count stats from all comments including gemini
+		total, reviews, reviewComments, issueComments, outdated, resolved, geminiReviews := m.pr.GetStatsForAllCommentsWithGemini()
 		
 		b.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%d reviews, %d review comments, %d general)", 
 			total, reviews, reviewComments, issueComments)))
 		b.WriteString("\n")
 		
-		if outdated > 0 || resolved > 0 {
-			b.WriteString(statusStyle.Render(fmt.Sprintf("Including: %d outdated, %d resolved", outdated, resolved)))
+		if outdated > 0 || resolved > 0 || geminiReviews > 0 {
+			filterInfo := fmt.Sprintf("Including: %d outdated, %d resolved", outdated, resolved)
+			if geminiReviews > 0 {
+				filterInfo += fmt.Sprintf(", %d gemini", geminiReviews)
+			}
+			b.WriteString(statusStyle.Render(filterInfo))
 			b.WriteString("\n")
 		}
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -357,9 +357,34 @@ func (m PRReviewModel) View() string {
 	// Debug: show viewport dimensions
 	// scrollInfo += fmt.Sprintf(" | H:%d/%d", m.viewport.Height, m.height)
 	
-	total, reviews, reviewComments, issueComments, _, _ := m.pr.GetCommentStats()
-	header.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%dR %dRC %dG), %d accepted | %d/%d%s", 
-		total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(m.pr.Comments), scrollInfo)))
+	comments := m.getActiveComments()
+	if m.filterEnabled {
+		total, reviews, reviewComments, issueComments, _, _ := m.pr.GetCommentStats()
+		header.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%dR %dRC %dG), %d accepted | %d/%d%s", 
+			total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(comments), scrollInfo)))
+	} else {
+		// Count stats from all comments
+		var total, reviews, reviewComments, issueComments, outdated, resolved int
+		for _, comment := range m.pr.AllComments {
+			total++
+			if comment.IsOutdated {
+				outdated++
+			}
+			if comment.IsResolved {
+				resolved++
+			}
+			switch comment.Type {
+			case "review":
+				reviews++
+			case "review_comment":
+				reviewComments++
+			case "issue_comment":
+				issueComments++
+			}
+		}
+		header.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%dR %dRC %dG, %d outdated, %d resolved), %d accepted | %d/%d%s", 
+			total, reviews, reviewComments, issueComments, outdated, resolved, acceptedCount, m.currentIndex+1, len(comments), scrollInfo)))
+	}
 	header.WriteString("\n") // Single newline after status
 
 	// Build the footer (help text)

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -272,6 +272,14 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+// getActiveComments returns the comments based on filter state
+func (m *PRReviewModel) getActiveComments() []git.PRComment {
+	if m.filterEnabled {
+		return m.pr.Comments
+	}
+	return m.pr.AllComments
+}
+
 func (m PRReviewModel) View() string {
 	if m.err != nil {
 		return fmt.Sprintf("Error: %v\n\nPress 'q' to go back", m.err)

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -346,10 +346,14 @@ func (m PRReviewModel) View() string {
 		header.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%dR %dRC %dG), %d accepted | %d/%d%s", 
 			total, reviews, reviewComments, issueComments, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	} else {
-		// Count stats from all comments
-		total, reviews, reviewComments, issueComments, outdated, resolved := m.pr.GetStatsForAllComments()
-		header.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%dR %dRC %dG, %d outdated, %d resolved), %d accepted | %d/%d%s", 
-			total, reviews, reviewComments, issueComments, outdated, resolved, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
+		// Count stats from all comments including gemini
+		total, reviews, reviewComments, issueComments, outdated, resolved, geminiReviews := m.pr.GetStatsForAllCommentsWithGemini()
+		filterInfo := fmt.Sprintf("%d outdated, %d resolved", outdated, resolved)
+		if geminiReviews > 0 {
+			filterInfo += fmt.Sprintf(", %d gemini", geminiReviews)
+		}
+		header.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%dR %dRC %dG, %s), %d accepted | %d/%d%s", 
+			total, reviews, reviewComments, issueComments, filterInfo, acceptedCount, m.currentIndex+1, len(activeComments), scrollInfo)))
 	}
 	header.WriteString("\n") // Single newline after status
 

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -281,7 +281,7 @@ func (m PRReviewModel) View() string {
 	comments := m.getActiveComments()
 	if len(comments) == 0 {
 		if m.filterEnabled && len(m.pr.AllComments) > 0 {
-			return "No active comments found on this PR (all are outdated/resolved).\n\nPress 'f' to show all comments\nPress 'q' to go back"
+			return "No active comments found on this PR (all are outdated/resolved/gemini).\n\nPress 'f' to show all comments\nPress 'q' to go back"
 		}
 		return "No comments found on this PR.\n\nPress 'q' to go back"
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -215,9 +215,23 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "A":
+			// Accept all comments in the current view
 			comments := m.getActiveComments()
-			for i := range comments {
-				comments[i].Accepted = true
+			for _, comment := range comments {
+				// Update in AllComments
+				for i := range m.pr.AllComments {
+					if m.pr.AllComments[i].ID == comment.ID {
+						m.pr.AllComments[i].Accepted = true
+						break
+					}
+				}
+				// Update in filtered comments if applicable
+				for i := range m.pr.Comments {
+					if m.pr.Comments[i].ID == comment.ID {
+						m.pr.Comments[i].Accepted = true
+						break
+					}
+				}
 			}
 			if m.ready {
 				m.updateViewportContent()
@@ -225,9 +239,23 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "D":
+			// Deny all comments in the current view
 			comments := m.getActiveComments()
-			for i := range comments {
-				comments[i].Accepted = false
+			for _, comment := range comments {
+				// Update in AllComments
+				for i := range m.pr.AllComments {
+					if m.pr.AllComments[i].ID == comment.ID {
+						m.pr.AllComments[i].Accepted = false
+						break
+					}
+				}
+				// Update in filtered comments if applicable
+				for i := range m.pr.Comments {
+					if m.pr.Comments[i].ID == comment.ID {
+						m.pr.Comments[i].Accepted = false
+						break
+					}
+				}
 			}
 			if m.ready {
 				m.updateViewportContent()

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -608,11 +608,15 @@ func (m PRReviewModel) simpleView() string {
 	b.WriteString(headerStyle.Render(fmt.Sprintf("PR #%d: %s", m.pr.Number, m.pr.Title)))
 	b.WriteString("\n")
 	
-	// Show that data is fresh
-	freshStyle := lipgloss.NewStyle().
+	// Show filter status
+	filterStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("28")).
 		Italic(true)
-	b.WriteString(freshStyle.Render("(Fresh data - automatically excludes outdated and resolved comments)"))
+	if m.filterEnabled {
+		b.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved)"))
+	} else {
+		b.WriteString(filterStyle.Render("(Filter: OFF - showing all comments)"))
+	}
 	b.WriteString("\n\n")
 	
 	acceptedCount := len(m.pr.GetAcceptedComments())

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -426,9 +426,12 @@ func (m *PRReviewModel) updateViewportContent() {
 			status = "[✓]"
 		}
 		
-		// Add visual indicator if comment was originally resolved but still showing (shouldn't happen)
+		// Add visual indicators for filtered comment types
 		if comment.IsResolved {
 			status += " (resolved)"
+		}
+		if comment.IsGeminiReview {
+			status += " (gemini)"
 		}
 
 		// Build header with better type display
@@ -646,9 +649,12 @@ func (m PRReviewModel) simpleView() string {
 			status = "[✓]"
 		}
 		
-		// Add visual indicator if comment was originally resolved but still showing (shouldn't happen)
+		// Add visual indicators for filtered comment types
 		if comment.IsResolved {
 			status += " (resolved)"
+		}
+		if comment.IsGeminiReview {
+			status += " (gemini)"
 		}
 		
 		b.WriteString(fmt.Sprintf("Comment %d/%d:\n", m.currentIndex+1, len(comments)))

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -147,7 +147,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "j", "down":
-			if m.currentIndex < len(m.pr.Comments)-1 {
+			if m.currentIndex < len(m.getActiveComments())-1 {
 				m.currentIndex++
 				if m.ready {
 					m.updateViewportContent()
@@ -167,8 +167,9 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "a":
-			if len(m.pr.Comments) > 0 {
-				m.pr.Comments[m.currentIndex].Accepted = true
+			comments := m.getActiveComments()
+			if len(comments) > 0 {
+				comments[m.currentIndex].Accepted = true
 				if m.ready {
 					m.updateViewportContent()
 				}
@@ -176,8 +177,9 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "d":
-			if len(m.pr.Comments) > 0 {
-				m.pr.Comments[m.currentIndex].Accepted = false
+			comments := m.getActiveComments()
+			if len(comments) > 0 {
+				comments[m.currentIndex].Accepted = false
 				if m.ready {
 					m.updateViewportContent()
 				}
@@ -185,8 +187,9 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "A":
-			for i := range m.pr.Comments {
-				m.pr.Comments[i].Accepted = true
+			comments := m.getActiveComments()
+			for i := range comments {
+				comments[i].Accepted = true
 			}
 			if m.ready {
 				m.updateViewportContent()
@@ -194,8 +197,9 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			return m, nil
 		
 		case "D":
-			for i := range m.pr.Comments {
-				m.pr.Comments[i].Accepted = false
+			comments := m.getActiveComments()
+			for i := range comments {
+				comments[i].Accepted = false
 			}
 			if m.ready {
 				m.updateViewportContent()
@@ -241,7 +245,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			if m.ready {
 				m.viewport.GotoTop()
 			}
-			if len(m.pr.Comments) > 0 {
+			if len(m.getActiveComments()) > 0 {
 				m.currentIndex = 0
 				if m.ready {
 					m.updateViewportContent()
@@ -253,8 +257,8 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			if m.ready {
 				m.viewport.GotoBottom()
 			}
-			if len(m.pr.Comments) > 0 {
-				m.currentIndex = len(m.pr.Comments) - 1
+			if len(m.getActiveComments()) > 0 {
+				m.currentIndex = len(m.getActiveComments()) - 1
 				if m.ready {
 					m.updateViewportContent()
 				}
@@ -291,6 +295,11 @@ func (m PRReviewModel) View() string {
 	}
 
 	if len(m.pr.Comments) == 0 {
+	comments := m.getActiveComments()
+	if len(comments) == 0 {
+		if m.filterEnabled && len(m.pr.AllComments) > 0 {
+			return "No active comments found on this PR (all are outdated/resolved).\n\nPress 'f' to show all comments\nPress 'q' to go back"
+		}
 		return "No comments found on this PR.\n\nPress 'q' to go back"
 	}
 

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -699,7 +699,7 @@ func (m PRReviewModel) simpleView() string {
 			status += " (resolved)"
 		}
 		
-		b.WriteString(fmt.Sprintf("Comment %d/%d:\n", m.currentIndex+1, len(m.pr.Comments)))
+		b.WriteString(fmt.Sprintf("Comment %d/%d:\n", m.currentIndex+1, len(comments)))
 		
 		// Format comment type with better descriptions
 		typeDisplay := comment.Type

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -168,8 +168,22 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 		
 		case "a":
 			comments := m.getActiveComments()
-			if len(comments) > 0 {
-				comments[m.currentIndex].Accepted = true
+			if len(comments) > 0 && m.currentIndex < len(comments) {
+				// Find and update the comment in AllComments
+				targetID := comments[m.currentIndex].ID
+				for i := range m.pr.AllComments {
+					if m.pr.AllComments[i].ID == targetID {
+						m.pr.AllComments[i].Accepted = true
+						break
+					}
+				}
+				// Also update in filtered comments if applicable
+				for i := range m.pr.Comments {
+					if m.pr.Comments[i].ID == targetID {
+						m.pr.Comments[i].Accepted = true
+						break
+					}
+				}
 				if m.ready {
 					m.updateViewportContent()
 				}
@@ -178,8 +192,22 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 		
 		case "d":
 			comments := m.getActiveComments()
-			if len(comments) > 0 {
-				comments[m.currentIndex].Accepted = false
+			if len(comments) > 0 && m.currentIndex < len(comments) {
+				// Find and update the comment in AllComments
+				targetID := comments[m.currentIndex].ID
+				for i := range m.pr.AllComments {
+					if m.pr.AllComments[i].ID == targetID {
+						m.pr.AllComments[i].Accepted = false
+						break
+					}
+				}
+				// Also update in filtered comments if applicable
+				for i := range m.pr.Comments {
+					if m.pr.Comments[i].ID == targetID {
+						m.pr.Comments[i].Accepted = false
+						break
+					}
+				}
 				if m.ready {
 					m.updateViewportContent()
 				}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -326,11 +326,15 @@ func (m PRReviewModel) View() string {
 	header.WriteString(titleLine)
 	header.WriteString("\n")
 	
-	// Show that data is fresh
-	freshStyle := lipgloss.NewStyle().
+	// Show filter status
+	filterStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("28")).
 		Italic(true)
-	header.WriteString(freshStyle.Render("(Fresh data - excludes outdated/resolved)"))
+	if m.filterEnabled {
+		header.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved)"))
+	} else {
+		header.WriteString(filterStyle.Render("(Filter: OFF - showing all comments)"))
+	}
 	header.WriteString("\n")
 
 	acceptedCount := len(m.pr.GetAcceptedComments())

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -736,7 +736,7 @@ func (m PRReviewModel) simpleView() string {
 		Foreground(lipgloss.Color("241"))
 	
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • Enter:process • q:cancel"))
+	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • f:toggle filter • Enter:process • q:cancel"))
 
 	return b.String()
 }

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -614,7 +614,7 @@ func (m PRReviewModel) simpleView() string {
 		allTotal := len(m.pr.AllComments)
 		filtered := allTotal - total
 		if filtered > 0 {
-			b.WriteString(statusStyle.Render(fmt.Sprintf("Filtered out: %d outdated/resolved", filtered)))
+			b.WriteString(statusStyle.Render(fmt.Sprintf("Filtered out: %d outdated/resolved/gemini", filtered)))
 			b.WriteString("\n")
 		}
 	} else {

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -399,6 +399,7 @@ func (m PRReviewModel) View() string {
 			"A/D:all",
 			"e:expand",
 			"s:split",
+			"f:toggle filter",
 			"Enter:process",
 			"q:cancel",
 			"PgUp/PgDn:scroll",

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -620,35 +620,64 @@ func (m PRReviewModel) simpleView() string {
 	b.WriteString("\n\n")
 	
 	acceptedCount := len(m.pr.GetAcceptedComments())
-	total, reviews, reviewComments, issueComments, outdated, resolved := m.pr.GetCommentStats()
 	
 	statusStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("241"))
 	
-	// Show comment breakdown
-	b.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d total (%d reviews, %d review comments, %d general)", 
-		total, reviews, reviewComments, issueComments)))
-	b.WriteString("\n")
+	comments := m.getActiveComments()
 	
-	if outdated > 0 || resolved > 0 {
-		filteredText := ""
-		if outdated > 0 && resolved > 0 {
-			filteredText = fmt.Sprintf("Filtered out: %d outdated, %d resolved", outdated, resolved)
-		} else if outdated > 0 {
-			filteredText = fmt.Sprintf("Filtered out: %d outdated", outdated)
-		} else if resolved > 0 {
-			filteredText = fmt.Sprintf("Filtered out: %d resolved", resolved)
-		}
-		b.WriteString(statusStyle.Render(filteredText))
+	if m.filterEnabled {
+		total, reviews, reviewComments, issueComments, _, _ := m.pr.GetCommentStats()
+		
+		// Show comment breakdown
+		b.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%d reviews, %d review comments, %d general)", 
+			total, reviews, reviewComments, issueComments)))
 		b.WriteString("\n")
+		
+		// Count filtered comments
+		allTotal := len(m.pr.AllComments)
+		filtered := allTotal - total
+		if filtered > 0 {
+			b.WriteString(statusStyle.Render(fmt.Sprintf("Filtered out: %d outdated/resolved", filtered)))
+			b.WriteString("\n")
+		}
+	} else {
+		// Count stats from all comments
+		var total, reviews, reviewComments, issueComments, outdated, resolved int
+		for _, comment := range m.pr.AllComments {
+			total++
+			if comment.IsOutdated {
+				outdated++
+			}
+			if comment.IsResolved {
+				resolved++
+			}
+			switch comment.Type {
+			case "review":
+				reviews++
+			case "review_comment":
+				reviewComments++
+			case "issue_comment":
+				issueComments++
+			}
+		}
+		
+		b.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%d reviews, %d review comments, %d general)", 
+			total, reviews, reviewComments, issueComments)))
+		b.WriteString("\n")
+		
+		if outdated > 0 || resolved > 0 {
+			b.WriteString(statusStyle.Render(fmt.Sprintf("Including: %d outdated, %d resolved", outdated, resolved)))
+			b.WriteString("\n")
+		}
 	}
 	
 	b.WriteString(statusStyle.Render(fmt.Sprintf("Accepted: %d", acceptedCount)))
 	b.WriteString("\n\n")
 	
 	// Show current comment
-	if len(m.pr.Comments) > 0 && m.currentIndex < len(m.pr.Comments) {
-		comment := m.pr.Comments[m.currentIndex]
+	if len(comments) > 0 && m.currentIndex < len(comments) {
+		comment := comments[m.currentIndex]
 		
 		status := "[ ]"
 		if comment.IsSplit {

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -181,20 +181,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			isAcceptAll := msg.String() == "A"
 			comments := m.getActiveComments()
 			for _, comment := range comments {
-				// Update in AllComments
-				for i := range m.pr.AllComments {
-					if m.pr.AllComments[i].ID == comment.ID {
-						m.pr.AllComments[i].Accepted = isAcceptAll
-						break
-					}
-				}
-				// Update in filtered comments if applicable
-				for i := range m.pr.Comments {
-					if m.pr.Comments[i].ID == comment.ID {
-						m.pr.Comments[i].Accepted = isAcceptAll
-						break
-					}
-				}
+				comment.Accepted = isAcceptAll
 			}
 			if m.ready {
 				m.updateViewportContent()

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -634,24 +634,7 @@ func (m PRReviewModel) simpleView() string {
 		}
 	} else {
 		// Count stats from all comments
-		var total, reviews, reviewComments, issueComments, outdated, resolved int
-		for _, comment := range m.pr.AllComments {
-			total++
-			if comment.IsOutdated {
-				outdated++
-			}
-			if comment.IsResolved {
-				resolved++
-			}
-			switch comment.Type {
-			case "review":
-				reviews++
-			case "review_comment":
-				reviewComments++
-			case "issue_comment":
-				issueComments++
-			}
-		}
+		total, reviews, reviewComments, issueComments, outdated, resolved := m.pr.GetStatsForAllComments()
 		
 		b.WriteString(statusStyle.Render(fmt.Sprintf("All Comments: %d (%d reviews, %d review comments, %d general)", 
 			total, reviews, reviewComments, issueComments)))

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -589,7 +589,7 @@ func (m PRReviewModel) simpleView() string {
 		Foreground(lipgloss.Color("28")).
 		Italic(true)
 	if m.filterEnabled {
-		b.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved)"))
+		b.WriteString(filterStyle.Render("(Filter: ON - hiding outdated/resolved/gemini)"))
 	} else {
 		b.WriteString(filterStyle.Render("(Filter: OFF - showing all comments)"))
 	}

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -413,7 +413,7 @@ func (m PRReviewModel) View() string {
 	// Debug: show viewport dimensions
 	// scrollInfo += fmt.Sprintf(" | H:%d/%d", m.viewport.Height, m.height)
 	
-	comments := m.getActiveComments()
+	activeComments := m.getActiveComments()
 	if m.filterEnabled {
 		total, reviews, reviewComments, issueComments, _, _ := m.pr.GetCommentStats()
 		header.WriteString(statusStyle.Render(fmt.Sprintf("Comments: %d (%dR %dRC %dG), %d accepted | %d/%d%s", 


### PR DESCRIPTION
This pull request introduces a new filtering mechanism for pull request comments, allowing users to toggle between viewing only active comments (excluding outdated/resolved ones) or all comments. The changes span both the backend logic for comment handling and the user interface for the PR review model. Key updates include separating filtered and all comments, adding a toggle filter option, and updating the UI to reflect the filter state.

### Backend Changes: Comment Handling
* Added a new `AllComments` field to the `PullRequest` struct to store all comments, including outdated and resolved ones, while keeping `Comments` for filtered (active) comments. (`session/git/pr_comments.go`, [session/git/pr_comments.goL50-R51](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32L50-R51))
* Updated the `FetchComments` method to populate both `AllComments` and `Comments`, with logic to filter out outdated/resolved comments for `Comments`. (`session/git/pr_comments.go`, [session/git/pr_comments.goR119-R126](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32R119-R126))
* Modified comment-fetching methods (`fetchReviews`, `fetchReviewComments`, `fetchIssueComments`) to append comments to `AllComments` instead of `Comments`. (`session/git/pr_comments.go`, [[1]](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32L264-R273) [[2]](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32L352-R355) [[3]](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32L405-R417)

### UI Changes: PR Review Model
* Introduced a `filterEnabled` field in `PRReviewModel` to track the filter state, defaulting to enabled. (`ui/pr_review.go`, [[1]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR19) [[2]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR36)
* Added a new `getActiveComments` helper method to return either `Comments` or `AllComments` based on the filter state. (`ui/pr_review.go`, [ui/pr_review.goR283-R300](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR283-R300))
* Implemented a toggle filter feature (`f` key) to switch between filtered and all comments, resetting indices and updating the viewport accordingly. (`ui/pr_review.go`, [ui/pr_review.goR105-R116](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR105-R116))

### UI Enhancements
* Updated the status header and comment navigation to reflect the current filter state, showing appropriate counts and messages. (`ui/pr_review.go`, [[1]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eL243-R335) [[2]](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eR358-R385)
* Enhanced the help text and comment breakdown to include filter-specific information. (`ui/pr_review.go`, [ui/pr_review.goL555-R704](diffhunk://#diff-be6bbd30eea7ca28065f5d2e93fc133d417e8c7a1a41203e5b4a6cc371ba7b0eL555-R704))

These changes improve the flexibility of the PR review process by allowing users to focus on relevant comments while still having the option to view all comments when needed.