### PR TITLE
Austinamoruso/shifttab

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -891,13 +891,9 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		}
 		return m, m.instanceChanged()
 	case keys.KeyTab:
-		m.tabbedWindow.Toggle()
-		m.menu.SetInDiffTab(m.tabbedWindow.IsInDiffTab())
-		return m, m.instanceChanged()
+		return m.handleTabSwitch(false)
 	case keys.KeyShiftTab:
-		m.tabbedWindow.ToggleReverse()
-		m.menu.SetInDiffTab(m.tabbedWindow.IsInDiffTab())
-		return m, m.instanceChanged()
+		return m.handleTabSwitch(true)
 	case keys.KeyDiffAll:
 		if m.tabbedWindow.IsInDiffTab() {
 			m.tabbedWindow.SetDiffModeAll()

--- a/app/app.go
+++ b/app/app.go
@@ -894,6 +894,10 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		m.tabbedWindow.Toggle()
 		m.menu.SetInDiffTab(m.tabbedWindow.IsInDiffTab())
 		return m, m.instanceChanged()
+	case keys.KeyShiftTab:
+		m.tabbedWindow.ToggleReverse()
+		m.menu.SetInDiffTab(m.tabbedWindow.IsInDiffTab())
+		return m, m.instanceChanged()
 	case keys.KeyDiffAll:
 		if m.tabbedWindow.IsInDiffTab() {
 			m.tabbedWindow.SetDiffModeAll()

--- a/app/app.go
+++ b/app/app.go
@@ -1199,6 +1199,17 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 	}
 }
 
+// handleTabSwitch handles tab switching in both forward and reverse directions
+func (m *home) handleTabSwitch(reverse bool) (tea.Model, tea.Cmd) {
+	if reverse {
+		m.tabbedWindow.ToggleReverse()
+	} else {
+		m.tabbedWindow.Toggle()
+	}
+	m.menu.SetInDiffTab(m.tabbedWindow.IsInDiffTab())
+	return m, m.instanceChanged()
+}
+
 // instanceChanged updates the AI pane, menu, diff pane, and terminal pane based on the selected instance. It returns an error
 // Cmd if there was any error.
 func (m *home) openIDE(instance *session.Instance) tea.Cmd {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -370,6 +370,7 @@ func DefaultKeyBindings() *KeyBindingsConfig {
 			// Actions
 			{Command: "enter", Keys: []string{"enter", "o"}, Help: "↵/o"},
 			{Command: "tab", Keys: []string{"tab"}, Help: "tab"},
+			{Command: "shift_tab", Keys: []string{"shift+tab"}, Help: "shift+tab"},
 			{Command: "help", Keys: []string{"?"}, Help: "?"},
 			{Command: "quit", Keys: []string{"q"}, Help: "q"},
 			{Command: "error_log", Keys: []string{"l"}, Help: "l"},

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -23,6 +23,7 @@ const (
 	KeyPRReview
 
 	KeyTab        // Tab is a special keybinding for switching between panes.
+	KeyShiftTab   // ShiftTab is a special keybinding for switching between panes in reverse.
 	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
 
 	KeyCheckout

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -579,6 +579,7 @@ func getHelpText(command string) string {
 		"open_ide":         "open IDE",
 		"rebase":           "rebase",
 		"tab":              "switch tab",
+		"shift_tab":        "switch tab (reverse)",
 		"scroll_up":        "scroll",
 		"scroll_down":      "scroll",
 		"home":             "scroll to top",

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -225,6 +225,10 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithKeys("tab"),
 		key.WithHelp("tab", "switch tab"),
 	),
+	KeyShiftTab: key.NewBinding(
+		key.WithKeys("shift+tab"),
+		key.WithHelp("shift+tab", "switch tab (reverse)"),
+	),
 	KeyResume: key.NewBinding(
 		key.WithKeys("r"),
 		key.WithHelp("r", "resume"),

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -96,6 +96,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"D":          KeyKill,
 	"q":          KeyQuit,
 	"tab":        KeyTab,
+	"shift+tab":  KeyShiftTab,
 	"c":          KeyCheckout,
 	"r":          KeyResume,
 	"p":          KeySubmit,

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -521,6 +521,7 @@ func getCommandToKeyNameMap() map[string]KeyName {
 		"open_ide":         KeyOpenIDE,
 		"rebase":           KeyRebase,
 		"tab":              KeyTab,
+		"shift_tab":        KeyShiftTab,
 		"scroll_up":        KeyShiftUp,
 		"scroll_down":      KeyShiftDown,
 		"home":             KeyHome,

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -107,11 +107,17 @@ func (w *TabbedWindow) GetPreviewSize() (width, height int) {
 }
 
 func (w *TabbedWindow) Toggle() {
+	if len(w.tabs) == 0 {
+		return
+	}
 	w.activeTab = (w.activeTab + 1) % len(w.tabs)
 }
 
 // ToggleReverse cycles through tabs in reverse order
 func (w *TabbedWindow) ToggleReverse() {
+	if len(w.tabs) == 0 {
+		return
+	}
 	w.activeTab = (w.activeTab - 1 + len(w.tabs)) % len(w.tabs)
 }
 

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -107,18 +107,21 @@ func (w *TabbedWindow) GetPreviewSize() (width, height int) {
 }
 
 func (w *TabbedWindow) Toggle() {
-	if len(w.tabs) == 0 {
-		return
-	}
-	w.activeTab = (w.activeTab + 1) % len(w.tabs)
+	w.cycleTabs(1)
 }
 
 // ToggleReverse cycles through tabs in reverse order
 func (w *TabbedWindow) ToggleReverse() {
+	w.cycleTabs(-1)
+}
+
+// cycleTabs handles cycling through tabs in a given direction.
+func (w *TabbedWindow) cycleTabs(direction int) {
 	if len(w.tabs) == 0 {
 		return
 	}
-	w.activeTab = (w.activeTab - 1 + len(w.tabs)) % len(w.tabs)
+	numTabs := len(w.tabs)
+	w.activeTab = (w.activeTab + direction + numTabs) % numTabs
 }
 
 // SetTab sets the active tab directly by index

--- a/ui/tabbed_window.go
+++ b/ui/tabbed_window.go
@@ -110,6 +110,11 @@ func (w *TabbedWindow) Toggle() {
 	w.activeTab = (w.activeTab + 1) % len(w.tabs)
 }
 
+// ToggleReverse cycles through tabs in reverse order
+func (w *TabbedWindow) ToggleReverse() {
+	w.activeTab = (w.activeTab - 1 + len(w.tabs)) % len(w.tabs)
+}
+
 // SetTab sets the active tab directly by index
 func (w *TabbedWindow) SetTab(tabIndex int) {
 	if tabIndex >= 0 && tabIndex < len(w.tabs) {


### PR DESCRIPTION
This pull request introduces a new feature that allows users to switch between tabs in reverse order using the `Shift+Tab` keybinding. The changes include updates to keybinding configurations, help text, and the implementation of the reverse tab-switching functionality.

### Keybinding Updates:
* Added a new keybinding, `KeyShiftTab`, for reverse tab switching in `keys/keys.go`. This includes updates to `GlobalKeyStringsMap`, `GlobalkeyBindings`, `DefaultKeyBindings`, `getCommandToKeyNameMap`, and `getHelpText`. (`[[1]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR26)`, `[[2]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR99)`, `[[3]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR228-R231)`, `[[4]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR373)`, `[[5]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR524)`, `[[6]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR582)`)

### Reverse Tab-Switching Implementation:
* Implemented a `ToggleReverse` method in the `TabbedWindow` class to cycle through tabs in reverse order. (`[ui/tabbed_window.goR113-R117](diffhunk://#diff-6252955ebc5793fedbe5f4277cf22867afa4025846142ff6fe1d65377c711860R113-R117)`)
* Integrated the `ToggleReverse` method into the `handleKeyPress` function in `app/app.go` to handle the `Shift+Tab` keybinding. (`[app/app.goR888-R891](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R888-R891)`)