### PR TITLE
Austinamoruso/gitresethead

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -143,6 +143,9 @@ type home struct {
 	// pendingRebaseInstance stores the instance to rebase after confirmation
 	pendingRebaseInstance *session.Instance
 	
+	// pendingResetInstance stores the instance to reset after confirmation
+	pendingResetInstance *session.Instance
+	
 	// rebaseInProgress indicates if a rebase is currently in progress
 	rebaseInProgress bool
 	// rebaseInstance is the instance being rebased

--- a/app/app.go
+++ b/app/app.go
@@ -1308,8 +1308,14 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			return m, nil
 		}
 
+		// Get the worktree to get branch name
+		worktree, err := selected.GetGitWorktree()
+		if err != nil {
+			return m, m.handleError(fmt.Errorf("failed to get git worktree: %w", err))
+		}
+		
 		// Show confirmation modal
-		message := fmt.Sprintf("[!] Reset session '%s' to origin/%s?", selected.Title, selected.BranchName)
+		message := fmt.Sprintf("[!] Reset session '%s' to origin/%s?", selected.Title, worktree.GetBranchName())
 		
 		// Store the selected instance for the reset
 		m.pendingResetInstance = selected

--- a/app/app.go
+++ b/app/app.go
@@ -1611,6 +1611,9 @@ type instanceChangedMsg struct{}
 // startRebaseMsg is sent to trigger the actual rebase after confirmation
 type startRebaseMsg struct{}
 
+// startGitResetMsg is sent to trigger the actual git reset after confirmation
+type startGitResetMsg struct{}
+
 // remotePollingMsg is sent to check if the remote branch has been updated
 type remotePollingMsg struct {
 	branchName  string

--- a/app/app.go
+++ b/app/app.go
@@ -1269,6 +1269,24 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		// For now, we'll just return without showing a message
 		// The update indicator will appear in the menu when the check completes
 		return m, nil
+	case keys.KeyGitReset:
+		selected := m.list.GetSelectedInstance()
+		if selected == nil {
+			return m, nil
+		}
+
+		// Show confirmation modal
+		message := fmt.Sprintf("[!] Reset session '%s' to origin/%s?", selected.Title, selected.BranchName)
+		
+		// Store the selected instance for the reset
+		m.pendingResetInstance = selected
+		
+		// Create a simple action that just returns a message to trigger the actual reset
+		resetAction := func() tea.Msg {
+			return startGitResetMsg{}
+		}
+		
+		return m, m.confirmAction(message, resetAction)
 	case keys.KeyEnter:
 		if m.list.NumInstances() == 0 {
 			return m, nil

--- a/app/app.go
+++ b/app/app.go
@@ -1318,6 +1318,11 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 			return m, nil
 		}
 
+		// Check if instance is paused
+		if selected.Paused() {
+			return m, m.handleError(fmt.Errorf(instancePausedError, selected.Title))
+		}
+
 		// Get the worktree to get branch name
 		worktree, err := selected.GetGitWorktree()
 		if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -511,12 +511,22 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.handleError(err)
 		}
 		
-		// Show success
-		timestamp := time.Now().Format("15:04:05")
-		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Git reset completed successfully for branch %s", timestamp, branchName))
+		// Show success message in the status bar
+		successMsg := fmt.Sprintf("✓ Git reset for branch %s completed successfully", branchName)
+		m.errBox.SetError(fmt.Errorf(successMsg))
 		
-		// Refresh instances after successful reset
-		return m, m.instanceChanged()
+		// Also add to log for history
+		timestamp := time.Now().Format("15:04:05")
+		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] %s", timestamp, successMsg))
+		
+		// Refresh instances and hide message after a delay
+		return m, tea.Batch(
+			m.instanceChanged(),
+			func() tea.Msg {
+				time.Sleep(3 * time.Second)
+				return hideErrMsg{}
+			},
+		)
 		
 	case remotePollingMsg:
 		// Check if rebase is still in progress

--- a/app/help.go
+++ b/app/help.go
@@ -108,6 +108,7 @@ func (h helpTypeInstanceStart) toContent() string {
 		keyStyle.Render("c")+descStyle.Render("     - Checkout this instance's branch"),
 		keyStyle.Render("p")+descStyle.Render("     - Commit and push branch to GitHub"),
 		keyStyle.Render("b")+descStyle.Render("     - Rebase with main branch"),
+		keyStyle.Render("h")+descStyle.Render("     - Git reset --hard to origin/branch"),
 		keyStyle.Render("B")+descStyle.Render("     - Create bookmark commit"),
 		keyStyle.Render("g")+descStyle.Render("     - Show git status"),
 		"",

--- a/app/help.go
+++ b/app/help.go
@@ -53,6 +53,7 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("c")+descStyle.Render("         - Checkout: commit changes and pause session"),
 		keyStyle.Render("r")+descStyle.Render("         - Resume a paused session"),
 		keyStyle.Render("b")+descStyle.Render("         - Rebase with main branch"),
+		keyStyle.Render("h")+descStyle.Render("         - Git reset --hard to origin/branch"),
 		keyStyle.Render("B")+descStyle.Render("         - Create bookmark commit"),
 		keyStyle.Render("g")+descStyle.Render("         - Show git status"),
 		keyStyle.Render("G")+descStyle.Render("         - Show git status bookmarks"),

--- a/app/help.go
+++ b/app/help.go
@@ -151,6 +151,7 @@ func (h helpTypeInstanceCheckout) toContent() string {
 		keyStyle.Render("r")+descStyle.Render(" - Resume a paused session"),
 		keyStyle.Render("p")+descStyle.Render(" - Commit and push branch to GitHub"),
 		keyStyle.Render("b")+descStyle.Render(" - Rebase with main branch"),
+		keyStyle.Render("h")+descStyle.Render(" - Git reset --hard to origin/branch"),
 		"",
 		dimStyle.Render("Note: The session is paused after checkout. Use 'r' to resume"),
 		dimStyle.Render("when you're ready to continue working with Claude Code."),

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -116,6 +116,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"g":          KeyGitStatus,
 	"G":          KeyGitStatusBookmark,
 	"U":          KeyCheckUpdate,
+	"h":          KeyGitReset,
 
 	// Jest navigation - these are only active in Jest tab
 	// "n" and "p" are already taken globally, so we'll handle them contextually

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -392,6 +392,7 @@ func DefaultKeyBindings() *KeyBindingsConfig {
 			{Command: "git_status", Keys: []string{"g"}, Help: "g"},
 			{Command: "git_status_bookmark", Keys: []string{"G"}, Help: "G"},
 			{Command: "check_update", Keys: []string{"U"}, Help: "U"},
+			{Command: "git_reset", Keys: []string{"h"}, Help: "h"},
 		},
 	}
 }

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -614,6 +614,7 @@ func getHelpText(command string) string {
 		"git_status":          "git status",
 		"git_status_bookmark": "git status bookmarks",
 		"check_update":        "check for updates",
+		"git_reset":           "git reset --hard",
 	}
 
 	if text, ok := helpTexts[command]; ok {

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -554,6 +554,7 @@ func getCommandToKeyNameMap() map[string]KeyName {
 		"git_status":          KeyGitStatus,
 		"git_status_bookmark": KeyGitStatusBookmark,
 		"check_update":        KeyCheckUpdate,
+		"git_reset":           KeyGitReset,
 	}
 }
 

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -64,6 +64,7 @@ const (
 	KeyGitStatus         // Key for showing git status overlay
 	KeyGitStatusBookmark // Key for showing git status overlay in bookmark mode
 	KeyCheckUpdate       // Key for checking for updates
+	KeyGitReset          // Key for git reset --hard origin/branch
 )
 
 // GlobalKeyStringsMap is a global, immutable map string to keybinding.

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -285,6 +285,10 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithKeys("U"),
 		key.WithHelp("U", "check for updates"),
 	),
+	KeyGitReset: key.NewBinding(
+		key.WithKeys("h"),
+		key.WithHelp("h", "git reset --hard"),
+	),
 
 	// -- Special keybindings --
 

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -185,31 +185,9 @@ func (g *GitWorktree) OpenBranchURL() error {
 
 // RebaseWithMain rebases the current branch with the main branch
 func (g *GitWorktree) RebaseWithMain() error {
-	// First, create a backup branch with a unique name
-	timestamp := time.Now().Unix()
-	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, timestamp)
-
-	// Ensure the backup branch name is unique by checking if it exists
-	for {
-		// Check if the branch already exists locally or remotely
-		localExists := false
-		remoteExists := false
-
-		if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "--verify", backupBranch); err == nil {
-			localExists = true
-		}
-		if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "--verify", fmt.Sprintf("origin/%s", backupBranch)); err == nil {
-			remoteExists = true
-		}
-
-		if !localExists && !remoteExists {
-			break
-		}
-
-		// If it exists, add a counter to make it unique
-		timestamp++
-		backupBranch = fmt.Sprintf("%s-backup-%d", g.branchName, timestamp)
-	}
+	// First, create a backup branch with a unique name.
+	// Using UnixNano is sufficient to avoid collisions and is more efficient than checking for existence.
+	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
 
 	if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
 		return fmt.Errorf("failed to create backup branch: %w", err)

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -352,7 +352,11 @@ func (g *GitWorktree) ResetToOrigin() error {
 		return fmt.Errorf("failed to reset to origin/%s. Backup branch created: %s. Error: %w", g.branchName, backupBranch, err)
 	}
 
-	log.InfoLog.Printf("Successfully reset branch %s to origin/%s. Backup branch: %s", g.branchName, g.branchName, backupBranch)
+	if isBackedUp {
+		log.InfoLog.Printf("Successfully reset branch %s to origin/%s. Using existing backup: %s", g.branchName, g.branchName, backupBranch)
+	} else {
+		log.InfoLog.Printf("Successfully reset branch %s to origin/%s. New backup branch: %s", g.branchName, g.branchName, backupBranch)
+	}
 	return nil
 }
 

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -225,18 +225,41 @@ func (g *GitWorktree) isCommitBackedUp(commitHash string) (bool, string, error) 
 
 // RebaseWithMain rebases the current branch with the main branch
 func (g *GitWorktree) RebaseWithMain() error {
-	// First, create a backup branch with a unique name.
-	// Using UnixNano is sufficient to avoid collisions and is more efficient than checking for existence.
-	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
+	// Get current commit hash to check if we need a backup
+	currentCommit, err := g.runGitCommand(g.worktreePath, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to get current commit: %w", err)
+	}
+	currentCommit = strings.TrimSpace(currentCommit)
 
-	if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
-		return fmt.Errorf("failed to create backup branch: %w", err)
+	// Check if the current commit is already backed up on a remote branch
+	isBackedUp, existingBackup, err := g.isCommitBackedUp(currentCommit)
+	if err != nil {
+		log.WarningLog.Printf("Failed to check for existing backups: %v", err)
+		// Continue with creating a new backup
+		isBackedUp = false
 	}
 
-	// Push the backup branch with --no-verify for speed
-	if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
-		// If push fails, just log it but continue
-		log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
+	var backupBranch string
+	if isBackedUp {
+		// Use the existing backup branch name
+		backupBranch = existingBackup
+		log.InfoLog.Printf("Current commit already backed up in branch: %s", backupBranch)
+	} else {
+		// Create a new backup branch with a unique name
+		backupBranch = fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
+
+		if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
+			return fmt.Errorf("failed to create backup branch: %w", err)
+		}
+
+		// Push the backup branch with --no-verify for speed
+		if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
+			// If push fails, just log it but continue
+			log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
+		} else {
+			log.InfoLog.Printf("Created and pushed new backup branch: %s", backupBranch)
+		}
 	}
 
 	// Fetch the latest from origin

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -205,13 +205,13 @@ func (g *GitWorktree) isCommitBackedUp(commitHash string) (bool, string, error) 
 			continue
 		}
 		
-		// Skip the current branch
-		if strings.Contains(branch, currentRemoteBranch) {
+		// Skip only if this is exactly the current branch (not a backup of it)
+		if branch == currentRemoteBranch {
 			continue
 		}
 		
 		// Check if this is a backup branch for our current branch
-		if strings.Contains(branch, fmt.Sprintf("%s-backup-", g.branchName)) {
+		if strings.Contains(branch, fmt.Sprintf("origin/%s-backup-", g.branchName)) {
 			// Extract just the branch name without "origin/" prefix
 			branchName := strings.TrimPrefix(branch, "origin/")
 			branchName = strings.TrimSpace(branchName)

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -263,31 +263,9 @@ func (g *GitWorktree) RebaseWithMain() error {
 
 // ResetToOrigin performs git fetch origin and git reset --hard origin/branch
 func (g *GitWorktree) ResetToOrigin() error {
-	// First, create a backup branch with a unique name
-	timestamp := time.Now().Unix()
-	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, timestamp)
-
-	// Ensure the backup branch name is unique by checking if it exists
-	for {
-		// Check if the branch already exists locally or remotely
-		localExists := false
-		remoteExists := false
-
-		if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "--verify", backupBranch); err == nil {
-			localExists = true
-		}
-		if _, err := g.runGitCommand(g.worktreePath, "rev-parse", "--verify", fmt.Sprintf("origin/%s", backupBranch)); err == nil {
-			remoteExists = true
-		}
-
-		if !localExists && !remoteExists {
-			break
-		}
-
-		// If it exists, add a counter to make it unique
-		timestamp++
-		backupBranch = fmt.Sprintf("%s-backup-%d", g.branchName, timestamp)
-	}
+	// First, create a backup branch with a unique name.
+	// Using UnixNano is sufficient to avoid collisions and is more efficient than checking for existence.
+	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
 
 	// Create backup branch from current state
 	if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -319,42 +319,10 @@ func (g *GitWorktree) RebaseWithMain() error {
 
 // ResetToOrigin performs git fetch origin and git reset --hard origin/branch
 func (g *GitWorktree) ResetToOrigin() error {
-	// Get current commit hash to check if we need a backup
-	currentCommit, err := g.runGitCommand(g.worktreePath, "rev-parse", "HEAD")
+	// Ensure we have a backup branch
+	backupBranch, isNew, err := g.ensureBackupBranch()
 	if err != nil {
-		return fmt.Errorf("failed to get current commit: %w", err)
-	}
-	currentCommit = strings.TrimSpace(currentCommit)
-
-	// Check if the current commit is already backed up on a remote branch
-	isBackedUp, existingBackup, err := g.isCommitBackedUp(currentCommit)
-	if err != nil {
-		log.WarningLog.Printf("Failed to check for existing backups: %v", err)
-		// Continue with creating a new backup
-		isBackedUp = false
-	}
-
-	var backupBranch string
-	if isBackedUp {
-		// Use the existing backup branch name
-		backupBranch = existingBackup
-		log.InfoLog.Printf("Current commit already backed up in branch: %s", backupBranch)
-	} else {
-		// Create a new backup branch with a unique name
-		backupBranch = fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
-
-		// Create backup branch from current state
-		if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
-			return fmt.Errorf("failed to create backup branch: %w", err)
-		}
-
-		// Push the backup branch with --no-verify for speed
-		if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
-			// If push fails, just log it but continue
-			log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
-		} else {
-			log.InfoLog.Printf("Created and pushed new backup branch: %s", backupBranch)
-		}
+		return err
 	}
 
 	// Fetch the latest from origin

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -335,10 +335,10 @@ func (g *GitWorktree) ResetToOrigin() error {
 		return fmt.Errorf("failed to reset to origin/%s. Backup branch created: %s. Error: %w", g.branchName, backupBranch, err)
 	}
 
-	if isBackedUp {
-		log.InfoLog.Printf("Successfully reset branch %s to origin/%s. Using existing backup: %s", g.branchName, g.branchName, backupBranch)
-	} else {
+	if isNew {
 		log.InfoLog.Printf("Successfully reset branch %s to origin/%s. New backup branch: %s", g.branchName, g.branchName, backupBranch)
+	} else {
+		log.InfoLog.Printf("Successfully reset branch %s to origin/%s. Using existing backup: %s", g.branchName, g.branchName, backupBranch)
 	}
 	return nil
 }

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -205,6 +205,14 @@ func (g *GitWorktree) isCommitBackedUp(commitHash string) (bool, string, error) 
 			continue
 		}
 
+		// Handle symbolic references like "origin/HEAD -> origin/main"
+		if strings.Contains(branch, " -> ") {
+			parts := strings.Split(branch, " -> ")
+			if len(parts) == 2 {
+				branch = strings.TrimSpace(parts[1])
+			}
+		}
+
 		// Skip only if this is exactly the current branch (not a backup of it)
 		if branch == currentRemoteBranch {
 			continue

--- a/session/git/worktree_git.go
+++ b/session/git/worktree_git.go
@@ -304,19 +304,42 @@ func (g *GitWorktree) RebaseWithMain() error {
 
 // ResetToOrigin performs git fetch origin and git reset --hard origin/branch
 func (g *GitWorktree) ResetToOrigin() error {
-	// First, create a backup branch with a unique name.
-	// Using UnixNano is sufficient to avoid collisions and is more efficient than checking for existence.
-	backupBranch := fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
+	// Get current commit hash to check if we need a backup
+	currentCommit, err := g.runGitCommand(g.worktreePath, "rev-parse", "HEAD")
+	if err != nil {
+		return fmt.Errorf("failed to get current commit: %w", err)
+	}
+	currentCommit = strings.TrimSpace(currentCommit)
 
-	// Create backup branch from current state
-	if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
-		return fmt.Errorf("failed to create backup branch: %w", err)
+	// Check if the current commit is already backed up on a remote branch
+	isBackedUp, existingBackup, err := g.isCommitBackedUp(currentCommit)
+	if err != nil {
+		log.WarningLog.Printf("Failed to check for existing backups: %v", err)
+		// Continue with creating a new backup
+		isBackedUp = false
 	}
 
-	// Push the backup branch with --no-verify for speed
-	if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
-		// If push fails, just log it but continue
-		log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
+	var backupBranch string
+	if isBackedUp {
+		// Use the existing backup branch name
+		backupBranch = existingBackup
+		log.InfoLog.Printf("Current commit already backed up in branch: %s", backupBranch)
+	} else {
+		// Create a new backup branch with a unique name
+		backupBranch = fmt.Sprintf("%s-backup-%d", g.branchName, time.Now().UnixNano())
+
+		// Create backup branch from current state
+		if _, err := g.runGitCommand(g.worktreePath, "branch", backupBranch); err != nil {
+			return fmt.Errorf("failed to create backup branch: %w", err)
+		}
+
+		// Push the backup branch with --no-verify for speed
+		if _, err := g.runGitCommand(g.worktreePath, "push", "origin", backupBranch, "--no-verify"); err != nil {
+			// If push fails, just log it but continue
+			log.WarningLog.Printf("failed to push backup branch %s: %v", backupBranch, err)
+		} else {
+			log.InfoLog.Printf("Created and pushed new backup branch: %s", backupBranch)
+		}
 	}
 
 	// Fetch the latest from origin


### PR DESCRIPTION
This pull request introduces a new feature to perform a `git reset --hard` operation on a selected branch, along with necessary UI and backend changes. The most important changes include adding a new method to handle the reset operation, updating the keybindings to trigger the reset, and integrating the feature into the application flow with confirmation prompts and error handling.

### Backend changes for git reset functionality:
* Added a new method `ResetToOrigin` in `GitWorktree` to perform `git reset --hard origin/branch` with a backup branch created for safety (`session/git/worktree_git.go`, [session/git/worktree_git.goR264-R316](diffhunk://#diff-3c832d07375a4577da5535171f6f8b3aa4a9ad411712f589e569e64b1f55aa82R264-R316)).
* Updated the `home` struct to include a `pendingResetInstance` field for tracking the instance to reset (`app/app.go`, [app/app.goR146-R148](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R146-R148)).
* Added a new message type `startGitResetMsg` to trigger the reset operation after user confirmation (`app/app.go`, [app/app.goR1650-R1652](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R1650-R1652)).

### UI and application flow updates:
* Enhanced the `Update` method to handle the `startGitResetMsg`, execute the reset operation, and log success or errors (`app/app.go`, [app/app.goR490-R519](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R490-R519)).
* Modified the `handleKeyPress` method to show a confirmation modal when the reset key is pressed and store the selected instance for reset (`app/app.go`, [app/app.goR1305-R1328](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R1305-R1328)).

### Keybinding updates:
* Introduced a new keybinding `h` for triggering the `git reset --hard` operation, with corresponding help text and configuration updates (`keys/keys.go`, [[1]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR67) [[2]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR119) [[3]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR288-R291) [[4]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR395) [[5]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR558) [[6]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR617).