### PR TITLE
Austinamoruso/resovleconversations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -2215,11 +2215,6 @@ func (m *home) showTestResults(output string) {
 }
 
 func (m *home) showErrorLog() (tea.Model, tea.Cmd) {
-	// Add a test entry to verify logging works
-	if len(m.errorLog) == 0 {
-		timestamp := time.Now().Format("15:04:05")
-		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Log opened - no previous entries", timestamp))
-	}
 	
 	// Create content for error log
 	var content string

--- a/app/app.go
+++ b/app/app.go
@@ -1402,6 +1402,66 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 		// Initialize the PR review model
 		initCmd := prReviewModel.Init()
 		return m, initCmd
+	case keys.KeyPRResolveConversations:
+		selected := m.list.GetSelectedInstance()
+		if selected == nil {
+			return m, nil
+		}
+
+		// Check if instance is started
+		if !selected.Started() {
+			return m, m.handleError(fmt.Errorf("instance '%s' is not started", selected.Title))
+		}
+
+		// Check if instance is paused
+		if selected.Paused() {
+			return m, m.handleError(fmt.Errorf(instancePausedError, selected.Title))
+		}
+
+		// Get the worktree for the selected instance
+		worktree, err := selected.GetGitWorktree()
+		if err != nil {
+			return m, m.handleError(fmt.Errorf("failed to get git worktree: %w", err))
+		}
+
+		// Get the worktree path
+		worktreePath := worktree.GetWorktreePath()
+
+		// Try to get PR and check for unresolved threads
+		var threads []string
+		var fetchError error
+		pr, err := git.GetCurrentPR(worktreePath)
+		if err == nil {
+			// We have a PR, try to get unresolved threads
+			threads, fetchError = pr.GetUnresolvedThreads(worktreePath)
+		} else {
+			fetchError = err
+		}
+
+		var message string
+		if fetchError == nil {
+			if len(threads) == 0 {
+				// No unresolved conversations
+				m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] No unresolved review threads found on PR", time.Now().Format("15:04:05")))
+				return m, m.handleError(fmt.Errorf("no unresolved review threads found on this PR"))
+			}
+			message = fmt.Sprintf("Found %d unresolved review threads on this PR.\n\nAre you sure you want to resolve all %d threads?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads), len(threads))
+		} else if strings.Contains(fetchError.Error(), "no pull request found") || 
+		          strings.Contains(fetchError.Error(), "no open pull requests") {
+			message = fmt.Sprintf("Error: %v\n\nThis feature requires an open GitHub pull request for the current branch.\n\nMake sure you:\n1. Have an open PR for this branch\n2. Are authenticated with 'gh auth login'\n3. Are in a git repository", fetchError)
+			return m, m.handleError(fetchError)
+		} else {
+			// Some other error occurred, but we'll still allow the user to try
+			message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
+		}
+
+		// Store the pending command to resolve conversations
+		m.pendingCmd = func() tea.Msg {
+			// When confirmed, send the message to resolve all conversations
+			return ui.PRResolveAllConversationsMsg{}
+		}
+
+		return m, m.confirmAction(message, m.pendingCmd)
 	case keys.KeyBookmark:
 		selected := m.list.GetSelectedInstance()
 		if selected == nil {

--- a/app/app.go
+++ b/app/app.go
@@ -2155,6 +2155,12 @@ func (m *home) showTestResults(output string) {
 }
 
 func (m *home) showErrorLog() (tea.Model, tea.Cmd) {
+	// Add a test entry to verify logging works
+	if len(m.errorLog) == 0 {
+		timestamp := time.Now().Format("15:04:05")
+		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Log opened - no previous entries", timestamp))
+	}
+	
 	// Create content for error log
 	var content string
 	if len(m.errorLog) == 0 {

--- a/app/app.go
+++ b/app/app.go
@@ -355,7 +355,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// If we couldn't get PR info or there are conversations to resolve, show confirmation
 			if message == "" {
-				message = "Are you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
+				message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
 			}
 
 			m.state = stateConfirm

--- a/app/app.go
+++ b/app/app.go
@@ -1824,6 +1824,97 @@ func (m *home) instanceChanged() tea.Cmd {
 	return nil
 }
 
+func (m *home) requestResolveAllConversationsConfirmation() (tea.Model, tea.Cmd) {
+	selected := m.list.GetSelectedInstance()
+	if selected == nil {
+		return m, m.handleError(fmt.Errorf("no instance selected"))
+	}
+
+	// Check if instance is started
+	if !selected.Started() {
+		return m, m.handleError(fmt.Errorf("instance '%s' is not started", selected.Title))
+	}
+
+	// Check if instance is paused
+	if selected.Paused() {
+		return m, m.handleError(fmt.Errorf(instancePausedError, selected.Title))
+	}
+
+	// Get the worktree for the selected instance
+	worktree, err := selected.GetGitWorktree()
+	if err != nil {
+		return m, m.handleError(fmt.Errorf("failed to get git worktree: %w", err))
+	}
+
+	// Get the worktree path
+	worktreePath := worktree.GetWorktreePath()
+
+	// Try to get PR and check for unresolved threads
+	var threads []string
+	var fetchError error
+	pr, err := git.GetCurrentPR(worktreePath)
+	if err == nil {
+		// We have a PR, try to get unresolved threads
+		threads, fetchError = pr.GetUnresolvedThreads(worktreePath)
+	} else {
+		fetchError = err
+	}
+
+	var message string
+	timestamp := time.Now().Format("15:04:05")
+	
+	if fetchError == nil {
+		if len(threads) == 0 {
+			// No unresolved conversations
+			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] No unresolved review threads found on PR", timestamp))
+			
+			// For PR review state, just show error
+			if m.state == statePRReview {
+				m.errBox.SetError(fmt.Errorf("No unresolved review threads found on this PR"))
+				return m, func() tea.Msg {
+					time.Sleep(2 * time.Second)
+					return hideErrMsg{}
+				}
+			}
+			// For main menu, return error
+			return m, m.handleError(fmt.Errorf("no unresolved review threads found on this PR"))
+		}
+		message = fmt.Sprintf("Found %d unresolved review threads on this PR.\n\nAre you sure you want to resolve all %d threads?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads), len(threads))
+	} else {
+		// Log the error
+		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Error fetching thread count: %v", timestamp, fetchError))
+		
+		if strings.Contains(fetchError.Error(), "no pull request found") || 
+		   strings.Contains(fetchError.Error(), "no open pull requests") {
+			message = fmt.Sprintf("Error: %v\n\nThis feature requires an open GitHub pull request for the current branch.\n\nMake sure you:\n1. Have an open PR for this branch\n2. Are authenticated with 'gh auth login'\n3. Are in a git repository", fetchError)
+			
+			// For main menu, return error immediately
+			if m.state != statePRReview {
+				return m, m.handleError(fetchError)
+			}
+		} else {
+			// Some other error occurred, but we'll still allow the user to try
+			message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
+		}
+	}
+
+	// Store the pending command to resolve conversations
+	m.pendingCmd = func() tea.Msg {
+		// When confirmed, send the message to resolve all conversations
+		return ui.PRResolveAllConversationsMsg{}
+	}
+
+	// For PR review state, set confirmation state differently
+	if m.state == statePRReview {
+		m.state = stateConfirm
+		m.confirmationOverlay = overlay.NewConfirmationOverlay(message)
+		return m, nil
+	}
+
+	// For main menu, use confirmAction
+	return m, m.confirmAction(message, m.pendingCmd)
+}
+
 type keyupMsg struct{}
 
 // keydownCallback clears the menu option highlighting after 500ms.

--- a/app/app.go
+++ b/app/app.go
@@ -375,7 +375,12 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// If we couldn't get PR info or there are conversations to resolve, show confirmation
 			if message == "" {
-				message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
+				if fetchError != nil {
+					// Show the specific error to the user
+					message = fmt.Sprintf("Error: %v\n\nThis feature requires an open GitHub pull request for the current branch.\n\nMake sure you:\n1. Have an open PR for this branch\n2. Are authenticated with 'gh auth login'\n3. Are in a git repository", fetchError)
+				} else {
+					message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
+				}
 			}
 
 			m.state = stateConfirm

--- a/app/app.go
+++ b/app/app.go
@@ -391,18 +391,6 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return ui.PRResolveAllConversationsMsg{}
 			}
 			return m, nil
-		case ui.PRResolveAllConversationsMsg:
-			// Resolve all conversations on the PR
-			m.state = stateHelp
-			m.prReviewOverlay = nil
-			m.confirmationOverlay = nil
-			m.textOverlay = overlay.NewTextOverlay("Resolving all PR conversations...\n\nThis may take a moment...")
-			
-			// Log the start of resolution
-			timestamp := time.Now().Format("15:04:05")
-			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Starting to resolve all PR conversations...", timestamp))
-			
-			return m, m.resolveAllPRConversations()
 		}
 
 		return m, cmd

--- a/app/app.go
+++ b/app/app.go
@@ -348,7 +348,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 									return hideErrMsg{}
 								}
 							}
-							message = fmt.Sprintf("Are you sure you want to resolve all %d unresolved review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads))
+							message = fmt.Sprintf("Found %d unresolved review threads on this PR.\n\nAre you sure you want to resolve all %d threads?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads), len(threads))
 						}
 					}
 				}

--- a/app/app.go
+++ b/app/app.go
@@ -355,7 +355,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// If we couldn't get PR info or there are conversations to resolve, show confirmation
 			if message == "" {
-				message = "Are you sure you want to resolve all conversations on this PR?\n\nThis action cannot be undone."
+				message = "Are you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
 			}
 
 			m.state = stateConfirm

--- a/app/app.go
+++ b/app/app.go
@@ -654,11 +654,11 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Show success message
 		var message string
 		if msg.total == 0 {
-			message = "✓ No unresolved conversations found"
+			message = "✓ No unresolved review threads found"
 		} else if msg.resolved == msg.total {
-			message = fmt.Sprintf("✓ Successfully resolved all %d conversations", msg.total)
+			message = fmt.Sprintf("✓ Successfully resolved all %d review threads", msg.total)
 		} else {
-			message = fmt.Sprintf("✓ Resolved %d of %d conversations", msg.resolved, msg.total)
+			message = fmt.Sprintf("✓ Resolved %d of %d review threads", msg.resolved, msg.total)
 		}
 
 		successErr := fmt.Errorf(message)

--- a/app/app.go
+++ b/app/app.go
@@ -348,7 +348,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 									return hideErrMsg{}
 								}
 							}
-							message = fmt.Sprintf("Are you sure you want to resolve all %d unresolved conversations on this PR?\n\nThis action cannot be undone.", len(threads))
+							message = fmt.Sprintf("Are you sure you want to resolve all %d unresolved review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads))
 						}
 					}
 				}

--- a/app/app.go
+++ b/app/app.go
@@ -706,6 +706,18 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		return m, nil
+	case ui.PRResolveAllConversationsMsg:
+		// Resolve all conversations on the PR
+		m.state = stateHelp
+		m.prReviewOverlay = nil
+		m.confirmationOverlay = nil
+		m.textOverlay = overlay.NewTextOverlay("Resolving all PR conversations...\n\nThis may take a moment...")
+		
+		// Log the start of resolution
+		timestamp := time.Now().Format("15:04:05")
+		m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Starting to resolve all PR conversations...", timestamp))
+		
+		return m, m.resolveAllPRConversations()
 	case testStartedMsg:
 		// Show non-obtrusive message that tests are running
 		m.errBox.SetError(fmt.Errorf("Running Jest tests..."))

--- a/app/app.go
+++ b/app/app.go
@@ -372,6 +372,11 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.prReviewOverlay = nil
 			m.confirmationOverlay = nil
 			m.textOverlay = overlay.NewTextOverlay("Resolving all PR conversations...\n\nThis may take a moment...")
+			
+			// Log the start of resolution
+			timestamp := time.Now().Format("15:04:05")
+			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Starting to resolve all PR conversations...", timestamp))
+			
 			return m, m.resolveAllPRConversations()
 		}
 

--- a/app/app.go
+++ b/app/app.go
@@ -651,26 +651,33 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.state = stateDefault
 		m.textOverlay = nil
 
+		// Add all logs from the operation
+		if len(msg.logs) > 0 {
+			m.errorLog = append(m.errorLog, msg.logs...)
+		}
+
 		timestamp := time.Now().Format("15:04:05")
 		
 		if msg.err != nil {
 			// Log the error
 			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Failed to resolve conversations: %v", timestamp, msg.err))
 			m.errBox.SetError(msg.err)
-			return m, nil
-		}
-
-		// Show success message
-		var message string
-		if msg.total == 0 {
-			message = "✓ No unresolved review threads found"
-			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] No unresolved review threads found on PR", timestamp))
-		} else if msg.resolved == msg.total {
-			message = fmt.Sprintf("✓ Successfully resolved all %d review threads", msg.total)
-			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Successfully resolved all %d review threads", timestamp, msg.total))
 		} else {
-			message = fmt.Sprintf("✓ Resolved %d of %d review threads", msg.resolved, msg.total)
-			m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Resolved %d of %d review threads (some failed)", timestamp, msg.resolved, msg.total))
+			// Show success message
+			var message string
+			if msg.total == 0 {
+				message = "✓ No unresolved review threads found"
+				m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] No unresolved review threads found on PR", timestamp))
+			} else if msg.resolved == msg.total {
+				message = fmt.Sprintf("✓ Successfully resolved all %d review threads", msg.total)
+				m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Successfully resolved all %d review threads", timestamp, msg.total))
+			} else {
+				message = fmt.Sprintf("✓ Resolved %d of %d review threads", msg.resolved, msg.total)
+				m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Resolved %d of %d review threads (some failed)", timestamp, msg.resolved, msg.total))
+			}
+			
+			successErr := fmt.Errorf(message)
+			m.errBox.SetError(successErr)
 		}
 		
 		// Keep log size manageable
@@ -678,12 +685,14 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.errorLog = m.errorLog[len(m.errorLog)-100:]
 		}
 
-		successErr := fmt.Errorf(message)
-		m.errBox.SetError(successErr)
-		return m, func() tea.Msg {
-			time.Sleep(3 * time.Second)
-			return hideErrMsg{}
+		// Return command to hide error after delay only if no error
+		if msg.err == nil {
+			return m, func() tea.Msg {
+				time.Sleep(3 * time.Second)
+				return hideErrMsg{}
+			}
 		}
+		return m, nil
 	case testStartedMsg:
 		// Show non-obtrusive message that tests are running
 		m.errBox.SetError(fmt.Errorf("Running Jest tests..."))

--- a/app/app.go
+++ b/app/app.go
@@ -332,65 +332,7 @@ func (m *home) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.state = stateCommentDetail
 			return m, tea.WindowSize()
 		case ui.PRRequestResolveConfirmationMsg:
-			// Show confirmation dialog for resolving all conversations
-			// But first, get the PR to check how many conversations there are
-			selected := m.list.GetSelectedInstance()
-			var message string
-			var fetchError error
-			
-			if selected != nil {
-				pr, err := git.GetCurrentPR(selected.Path)
-				if err != nil {
-					fetchError = fmt.Errorf("failed to get current PR: %w", err)
-				} else {
-					err = pr.FetchComments(selected.Path)
-					if err != nil {
-						fetchError = fmt.Errorf("failed to fetch comments: %w", err)
-					} else {
-						threads, err := pr.GetUnresolvedThreads(selected.Path)
-						if err != nil {
-							fetchError = fmt.Errorf("failed to get unresolved threads: %w", err)
-						} else {
-							if len(threads) == 0 {
-								// No unresolved conversations
-								m.errBox.SetError(fmt.Errorf("No unresolved review threads found on this PR"))
-								// Also log this
-								timestamp := time.Now().Format("15:04:05")
-								m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] No unresolved review threads found on PR", timestamp))
-								return m, func() tea.Msg {
-									time.Sleep(2 * time.Second)
-									return hideErrMsg{}
-								}
-							}
-							message = fmt.Sprintf("Found %d unresolved review threads on this PR.\n\nAre you sure you want to resolve all %d threads?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone.", len(threads), len(threads))
-						}
-					}
-				}
-				
-				// Log the error if we had one
-				if fetchError != nil {
-					timestamp := time.Now().Format("15:04:05")
-					m.errorLog = append(m.errorLog, fmt.Sprintf("[%s] Error fetching thread count: %v", timestamp, fetchError))
-				}
-			}
-			// If we couldn't get PR info or there are conversations to resolve, show confirmation
-			if message == "" {
-				if fetchError != nil {
-					// Show the specific error to the user
-					message = fmt.Sprintf("Error: %v\n\nThis feature requires an open GitHub pull request for the current branch.\n\nMake sure you:\n1. Have an open PR for this branch\n2. Are authenticated with 'gh auth login'\n3. Are in a git repository", fetchError)
-				} else {
-					message = "Unable to fetch thread count.\n\nAre you sure you want to resolve all review threads on this PR?\n\nNote: Only review threads (line comments) can be resolved.\nGeneral PR comments cannot be resolved.\n\nThis action cannot be undone."
-				}
-			}
-
-			m.state = stateConfirm
-			m.confirmationOverlay = overlay.NewConfirmationOverlay(message)
-			// Store the pending command to resolve conversations
-			m.pendingCmd = func() tea.Msg {
-				// When confirmed, send the message to resolve all conversations
-				return ui.PRResolveAllConversationsMsg{}
-			}
-			return m, nil
+			return m.requestResolveAllConversationsConfirmation()
 		}
 
 		return m, cmd

--- a/app/help.go
+++ b/app/help.go
@@ -64,6 +64,7 @@ func (h helpTypeGeneral) toContent() string {
 		keyStyle.Render("x")+descStyle.Render("         - Open in external diff tool"),
 		keyStyle.Render("t")+descStyle.Render("         - Run tests"),
 		keyStyle.Render("R")+descStyle.Render("         - Review PR comments"),
+		keyStyle.Render("ctrl+r")+descStyle.Render("    - Resolve all PR conversations"),
 		"",
 		headerStyle.Render("Navigation:"),
 		keyStyle.Render("tab")+descStyle.Render("       - Switch between AI, diff, and terminal tabs"),

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -217,8 +217,21 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 			return resolveConversationsMsg{err: fmt.Errorf("no instance selected")}
 		}
 
+		// Get the worktree for the selected instance
+		worktree, err := selected.GetGitWorktree()
+		if err != nil {
+			logs = append(logs, fmt.Sprintf("[%s] Failed to get git worktree: %v", timestamp, err))
+			return resolveConversationsMsg{
+				err: fmt.Errorf("failed to get git worktree: %w", err),
+				logs: logs,
+			}
+		}
+
+		// Get the worktree path
+		worktreePath := worktree.GetWorktreePath()
+
 		// Get the current PR
-		pr, err := git.GetCurrentPR(selected.Path)
+		pr, err := git.GetCurrentPR(worktreePath)
 		if err != nil {
 			logs = append(logs, fmt.Sprintf("[%s] Failed to get current PR: %v", timestamp, err))
 			return resolveConversationsMsg{

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -204,6 +204,7 @@ type resolveConversationsMsg struct {
 	resolved int
 	total    int
 	err      error
+	logs     []string  // Log messages to add to errorLog
 }
 
 func (m *home) resolveAllPRConversations() tea.Cmd {

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -240,14 +240,6 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		
 		logs = append(logs, fmt.Sprintf("[%s] Found PR #%d: %s", timestamp, pr.Number, pr.Title))
 
-		// Fetch all comments to get thread IDs
-		if err := pr.FetchComments(worktreePath); err != nil {
-			return resolveConversationsMsg{
-				err: fmt.Errorf("failed to fetch PR comments: %w", err),
-				logs: logs,
-			}
-		}
-
 		// Get all unresolved conversations
 		unresolvedThreads, err := pr.GetUnresolvedThreads(worktreePath)
 		if err != nil {

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -220,7 +220,6 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		// Get the worktree for the selected instance
 		worktree, err := selected.GetGitWorktree()
 		if err != nil {
-			logs = append(logs, fmt.Sprintf("[%s] Failed to get git worktree: %v", timestamp, err))
 			return resolveConversationsMsg{
 				err: fmt.Errorf("failed to get git worktree: %w", err),
 				logs: logs,

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -232,7 +232,6 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		// Get the current PR
 		pr, err := git.GetCurrentPR(worktreePath)
 		if err != nil {
-			logs = append(logs, fmt.Sprintf("[%s] Failed to get current PR: %v", timestamp, err))
 			return resolveConversationsMsg{
 				err: fmt.Errorf("failed to get current PR: %w", err),
 				logs: logs,

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -243,7 +243,7 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		logs = append(logs, fmt.Sprintf("[%s] Found PR #%d: %s", timestamp, pr.Number, pr.Title))
 
 		// Fetch all comments to get thread IDs
-		if err := pr.FetchComments(selected.Path); err != nil {
+		if err := pr.FetchComments(worktreePath); err != nil {
 			logs = append(logs, fmt.Sprintf("[%s] Failed to fetch PR comments: %v", timestamp, err))
 			return resolveConversationsMsg{
 				err: fmt.Errorf("failed to fetch PR comments: %w", err),
@@ -252,7 +252,7 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		}
 
 		// Get all unresolved conversations
-		unresolvedThreads, err := pr.GetUnresolvedThreads(selected.Path)
+		unresolvedThreads, err := pr.GetUnresolvedThreads(worktreePath)
 		if err != nil {
 			logs = append(logs, fmt.Sprintf("[%s] Failed to get unresolved threads: %v", timestamp, err))
 			return resolveConversationsMsg{

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -268,7 +268,7 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 
 		// Resolve each thread
 		for i, threadID := range unresolvedThreads {
-			if err := pr.ResolveThread(selected.Path, threadID); err != nil {
+			if err := pr.ResolveThread(worktreePath, threadID); err != nil {
 				logs = append(logs, fmt.Sprintf("[%s] Failed to resolve thread %d/%d: %v", timestamp, i+1, total, err))
 				// Check if it's a permission error
 				if strings.Contains(err.Error(), "must have push access") || 

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -265,7 +265,7 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		// Resolve each thread
 		for i, threadID := range unresolvedThreads {
 			if err := pr.ResolveThread(worktreePath, threadID); err != nil {
-				logs = append(logs, fmt.Sprintf("[%s] Failed to resolve thread %d/%d: %v", timestamp, i+1, total, err))
+				logs = append(logs, fmt.Sprintf("[%s] Failed to resolve thread %d/%d", timestamp, i+1, total))
 				// Check if it's a permission error
 				if strings.Contains(err.Error(), "must have push access") || 
 				   strings.Contains(err.Error(), "resource not accessible") ||

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -251,7 +251,6 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		// Get all unresolved conversations
 		unresolvedThreads, err := pr.GetUnresolvedThreads(worktreePath)
 		if err != nil {
-			logs = append(logs, fmt.Sprintf("[%s] Failed to get unresolved threads: %v", timestamp, err))
 			return resolveConversationsMsg{
 				err: fmt.Errorf("failed to get unresolved threads: %w", err),
 				logs: logs,

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -213,18 +213,11 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 			return resolveConversationsMsg{err: fmt.Errorf("no instance selected")}
 		}
 
-		// Log the start of the operation
-		timestamp := time.Now().Format("15:04:05")
-		log.InfoLog.Printf("[%s] Starting to resolve all PR conversations", timestamp)
-
 		// Get the current PR
 		pr, err := git.GetCurrentPR(selected.Path)
 		if err != nil {
-			log.ErrorLog.Printf("[%s] Failed to get current PR: %v", timestamp, err)
 			return resolveConversationsMsg{err: fmt.Errorf("failed to get current PR: %w", err)}
 		}
-		
-		log.InfoLog.Printf("[%s] Found PR #%d: %s", timestamp, pr.Number, pr.Title)
 
 		// Fetch all comments to get thread IDs
 		if err := pr.FetchComments(selected.Path); err != nil {

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -213,11 +213,18 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 			return resolveConversationsMsg{err: fmt.Errorf("no instance selected")}
 		}
 
+		// Log the start of the operation
+		timestamp := time.Now().Format("15:04:05")
+		log.InfoLog.Printf("[%s] Starting to resolve all PR conversations", timestamp)
+
 		// Get the current PR
 		pr, err := git.GetCurrentPR(selected.Path)
 		if err != nil {
+			log.ErrorLog.Printf("[%s] Failed to get current PR: %v", timestamp, err)
 			return resolveConversationsMsg{err: fmt.Errorf("failed to get current PR: %w", err)}
 		}
+		
+		log.InfoLog.Printf("[%s] Found PR #%d: %s", timestamp, pr.Number, pr.Title)
 
 		// Fetch all comments to get thread IDs
 		if err := pr.FetchComments(selected.Path); err != nil {

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -242,7 +242,6 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 
 		// Fetch all comments to get thread IDs
 		if err := pr.FetchComments(worktreePath); err != nil {
-			logs = append(logs, fmt.Sprintf("[%s] Failed to fetch PR comments: %v", timestamp, err))
 			return resolveConversationsMsg{
 				err: fmt.Errorf("failed to fetch PR comments: %w", err),
 				logs: logs,

--- a/app/pr_processor.go
+++ b/app/pr_processor.go
@@ -237,6 +237,14 @@ func (m *home) resolveAllPRConversations() tea.Cmd {
 		for _, threadID := range unresolvedThreads {
 			if err := pr.ResolveThread(selected.Path, threadID); err != nil {
 				log.ErrorLog.Printf("Failed to resolve thread %s: %v", threadID, err)
+				// Check if it's a permission error
+				if strings.Contains(err.Error(), "must have push access") || 
+				   strings.Contains(err.Error(), "resource not accessible") ||
+				   strings.Contains(err.Error(), "permission") {
+					return resolveConversationsMsg{
+						err: fmt.Errorf("permission denied: you need write access to the repository to resolve conversations"),
+					}
+				}
 				continue
 			}
 			resolved++

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -21,6 +21,7 @@ const (
 	KeyPush
 	KeySubmit
 	KeyPRReview
+	KeyPRResolveConversations
 
 	KeyTab        // Tab is a special keybinding for switching between panes.
 	KeyShiftTab   // ShiftTab is a special keybinding for switching between panes in reverse.
@@ -109,6 +110,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"b":          KeyRebase,
 	"B":          KeyBookmark,
 	"R":          KeyPRReview,
+	"ctrl+r":     KeyPRResolveConversations,
 	"ctrl+h":     KeyHistory,
 	"K":          KeyEditKeybindings,
 	"t":          KeyTest,
@@ -252,6 +254,10 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	KeyPRReview: key.NewBinding(
 		key.WithKeys("R"),
 		key.WithHelp("R", "review PR comments"),
+	),
+	KeyPRResolveConversations: key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "resolve all PR conversations"),
 	),
 	KeyBookmark: key.NewBinding(
 		key.WithKeys("B"),

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -849,9 +849,10 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 	// Execute GraphQL query
 	cmd := exec.Command("gh", "api", "graphql", "-f", fmt.Sprintf("query=%s", query))
 	cmd.Dir = workingDir
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch review threads: %w", err)
+		// Include the output in the error for debugging
+		return nil, fmt.Errorf("failed to fetch review threads: %w (output: %s)", err, string(output))
 	}
 
 	var response struct {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -939,12 +939,15 @@ mutation {
 	}
 
 	if len(response.Errors) > 0 {
+		fmt.Printf("GraphQL error: %s\n", response.Errors[0].Message)
 		return fmt.Errorf("GraphQL error: %s", response.Errors[0].Message)
 	}
 
 	if !response.Data.ResolveReviewThread.Thread.IsResolved {
+		fmt.Printf("Thread %s was not resolved successfully\n", threadID)
 		return fmt.Errorf("thread %s was not resolved successfully", threadID)
 	}
 
+	fmt.Printf("Successfully resolved thread: %s\n", threadID)
 	return nil
 }

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -860,9 +860,18 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 			Repository struct {
 				PullRequest struct {
 					ReviewThreads struct {
+						TotalCount int `json:"totalCount"`
 						Nodes []struct {
 							ID         string `json:"id"`
 							IsResolved bool   `json:"isResolved"`
+							Comments struct {
+								Nodes []struct {
+									Body string `json:"body"`
+									Author struct {
+										Login string `json:"login"`
+									} `json:"author"`
+								} `json:"nodes"`
+							} `json:"comments"`
 						} `json:"nodes"`
 					} `json:"reviewThreads"`
 				} `json:"pullRequest"`

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -979,7 +979,7 @@ mutation($threadId: ID!) {
 	cmd.Dir = workingDir
 	output, err := cmd.CombinedOutput() // Use CombinedOutput to get stderr as well
 	if err != nil {
-		return fmt.Errorf("failed to resolve thread %s: %w (output: %s)", threadID, err, string(output))
+		return fmt.Errorf("failed to resolve thread %s (output: %s): %w", threadID, string(output), err)
 	}
 
 	// Check if mutation was successful

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -937,15 +937,12 @@ mutation($threadId: ID!) {
 	}
 
 	if len(response.Errors) > 0 {
-		fmt.Printf("GraphQL error: %s\n", response.Errors[0].Message)
 		return fmt.Errorf("GraphQL error: %s", response.Errors[0].Message)
 	}
 
 	if !response.Data.ResolveReviewThread.Thread.IsResolved {
-		fmt.Printf("Thread %s was not resolved successfully\n", threadID)
 		return fmt.Errorf("thread %s was not resolved successfully", threadID)
 	}
 
-	fmt.Printf("Successfully resolved thread: %s\n", threadID)
 	return nil
 }

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -914,12 +914,8 @@ mutation($threadId: ID!) {
 	cmd.Dir = workingDir
 	output, err := cmd.CombinedOutput() // Use CombinedOutput to get stderr as well
 	if err != nil {
-		fmt.Printf("Failed to resolve thread. Output: %s\n", string(output))
-		fmt.Printf("Thread ID was: %s\n", threadID)
 		return fmt.Errorf("failed to resolve thread %s: %w (output: %s)", threadID, err, string(output))
 	}
-	
-	fmt.Printf("GraphQL response: %s\n", string(output))
 
 	// Check if mutation was successful
 	var response struct {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -944,13 +944,17 @@ mutation {
 }`, threadID)
 
 	// Execute GraphQL mutation
-	cmd := exec.Command("gh", "api", "graphql", "-f", fmt.Sprintf("query=%s", mutation))
+	// Use --field instead of -f query= for proper escaping
+	cmd := exec.Command("gh", "api", "graphql", "--field", fmt.Sprintf("query=%s", mutation))
 	cmd.Dir = workingDir
 	output, err := cmd.CombinedOutput() // Use CombinedOutput to get stderr as well
 	if err != nil {
 		fmt.Printf("Failed to resolve thread. Output: %s\n", string(output))
+		fmt.Printf("Mutation was: %s\n", mutation)
 		return fmt.Errorf("failed to resolve thread %s: %w (output: %s)", threadID, err, string(output))
 	}
+	
+	fmt.Printf("GraphQL response: %s\n", string(output))
 
 	// Check if mutation was successful
 	var response struct {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -898,8 +898,6 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 
 // ResolveThread resolves a specific review thread
 func (pr *PullRequest) ResolveThread(workingDir string, threadID string) error {
-	fmt.Printf("Attempting to resolve thread: %s\n", threadID)
-	
 	// Use GraphQL mutation to resolve the thread
 	mutation := `
 mutation($threadId: ID!) {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -882,27 +882,15 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 		return nil, fmt.Errorf("failed to parse review threads response: %w", err)
 	}
 
-	// Log total count
+	// Get total count
 	totalThreads := response.Data.Repository.PullRequest.ReviewThreads.TotalCount
-	fmt.Printf("Total review threads: %d\n", totalThreads)
 	
 	// Collect unresolved thread IDs
 	var unresolvedThreads []string
 	for _, thread := range response.Data.Repository.PullRequest.ReviewThreads.Nodes {
 		if !thread.IsResolved {
 			unresolvedThreads = append(unresolvedThreads, thread.ID)
-			if len(thread.Comments.Nodes) > 0 {
-				comment := thread.Comments.Nodes[0]
-				fmt.Printf("  - Unresolved thread by @%s: %.50s...\n", comment.Author.Login, strings.ReplaceAll(comment.Body, "\n", " "))
-			}
 		}
-	}
-
-	fmt.Printf("Found %d unresolved threads out of %d total\n", len(unresolvedThreads), totalThreads)
-	
-	// Warn if we might have hit the pagination limit
-	if totalThreads > 100 {
-		fmt.Printf("WARNING: PR has %d threads but we only fetched 100. Some threads may be missed.\n", totalThreads)
 	}
 	
 	return unresolvedThreads, nil

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -802,7 +802,6 @@ func matchesNumberedList(line string) bool {
 
 // GetUnresolvedThreads returns all unresolved review thread IDs
 func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error) {
-	fmt.Printf("Getting unresolved threads for PR #%d\n", pr.Number)
 	// Get repository info first
 	repoCmd := exec.Command("gh", "repo", "view", "--json", "owner,name")
 	repoCmd.Dir = workingDir

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -882,9 +882,6 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 		return nil, fmt.Errorf("failed to parse review threads response: %w", err)
 	}
 
-	// Get total count
-	totalThreads := response.Data.Repository.PullRequest.ReviewThreads.TotalCount
-	
 	// Collect unresolved thread IDs
 	var unresolvedThreads []string
 	for _, thread := range response.Data.Repository.PullRequest.ReviewThreads.Nodes {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -907,7 +907,7 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			// Include the output in the error for debugging
-			return nil, fmt.Errorf("failed to fetch review threads: %w (output: %s)", err, string(output))
+			return nil, fmt.Errorf("failed to fetch review threads (output: %s): %w", string(output), err)
 		}
 
 		var response struct {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -88,7 +88,7 @@ func GetCurrentPR(workingDir string) (*PullRequest, error) {
 			return nil, fmt.Errorf("not in a git repository: %s", workingDir)
 		}
 		// Generic error with output for debugging
-		return nil, fmt.Errorf("failed to get current PR from %s: %w (output: %s)", workingDir, err, strings.TrimSpace(outputStr))
+		return nil, fmt.Errorf("failed to get current PR from %s (output: %s): %w", workingDir, strings.TrimSpace(outputStr), err)
 	}
 
 	var prData struct {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -913,9 +913,10 @@ mutation {
 	// Execute GraphQL mutation
 	cmd := exec.Command("gh", "api", "graphql", "-f", fmt.Sprintf("query=%s", mutation))
 	cmd.Dir = workingDir
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput() // Use CombinedOutput to get stderr as well
 	if err != nil {
-		return fmt.Errorf("failed to resolve thread %s: %w", threadID, err)
+		fmt.Printf("Failed to resolve thread. Output: %s\n", string(output))
+		return fmt.Errorf("failed to resolve thread %s: %w (output: %s)", threadID, err, string(output))
 	}
 
 	// Check if mutation was successful

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -912,25 +912,7 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 // ResolveThread resolves a specific review thread
 func (pr *PullRequest) ResolveThread(workingDir string, threadID string) error {
 	fmt.Printf("Attempting to resolve thread: %s\n", threadID)
-	// Get repository info first
-	repoCmd := exec.Command("gh", "repo", "view", "--json", "owner,name")
-	repoCmd.Dir = workingDir
-	repoOutput, err := repoCmd.Output()
-	if err != nil {
-		return fmt.Errorf("failed to get repository info: %w", err)
-	}
-
-	var repoInfo struct {
-		Owner struct {
-			Login string `json:"login"`
-		} `json:"owner"`
-		Name string `json:"name"`
-	}
-
-	if err := json.Unmarshal(repoOutput, &repoInfo); err != nil {
-		return fmt.Errorf("failed to parse repository info: %w", err)
-	}
-
+	
 	// Use GraphQL mutation to resolve the thread
 	mutation := `
 mutation($threadId: ID!) {

--- a/session/git/pr_comments.go
+++ b/session/git/pr_comments.go
@@ -823,14 +823,24 @@ func (pr *PullRequest) GetUnresolvedThreads(workingDir string) ([]string, error)
 	}
 
 	// Use GraphQL to get unresolved review threads
+	// Note: Using a higher limit to get all threads
 	query := fmt.Sprintf(`
 {
   repository(owner: "%s", name: "%s") {
     pullRequest(number: %d) {
       reviewThreads(first: 100) {
+        totalCount
         nodes {
           id
           isResolved
+          comments(first: 1) {
+            nodes {
+              body
+              author {
+                login
+              }
+            }
+          }
         }
       }
     }

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -831,7 +831,7 @@ func (m PRReviewModel) simpleView() string {
 		Foreground(lipgloss.Color("241"))
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • f:toggle filter • c/C:toggle/only comments • r/R:toggle/only reviews • l/L:toggle/only line comments • Ctrl+c:resolve all • Enter:process • q:cancel"))
+	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • f:toggle filter • c/C:toggle/only comments • r/R:toggle/only reviews • l/L:toggle/only line comments • Ctrl+r:resolve all • Enter:process • q:cancel"))
 
 	return b.String()
 }

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -501,7 +501,7 @@ func (m PRReviewModel) View() string {
 			"c/C:toggle/only comments",
 			"r/R:toggle/only reviews",
 			"l/L:toggle/only line comments",
-			"Ctrl+r:resolve all",
+			"Ctrl+c:resolve all",
 			"Enter:process",
 			"q:cancel",
 			"PgUp/PgDn:scroll",

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -501,7 +501,7 @@ func (m PRReviewModel) View() string {
 			"c/C:toggle/only comments",
 			"r/R:toggle/only reviews",
 			"l/L:toggle/only line comments",
-			"Ctrl+c:resolve all",
+			"Ctrl+r:resolve all",
 			"Enter:process",
 			"q:cancel",
 			"PgUp/PgDn:scroll",

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -188,7 +188,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			m = m.resetViewAfterFilterChange()
 			return m, nil
 
-		case "ctrl+r":
+		case "ctrl+c":
 			// Request confirmation before resolving all conversations
 			return m, func() tea.Msg { return PRRequestResolveConfirmationMsg{} }
 

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -831,7 +831,7 @@ func (m PRReviewModel) simpleView() string {
 		Foreground(lipgloss.Color("241"))
 
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • f:toggle filter • c/C:toggle/only comments • r/R:toggle/only reviews • l/L:toggle/only line comments • Ctrl+r:resolve all • Enter:process • q:cancel"))
+	b.WriteString(helpStyle.Render("Keys: j/k:nav • a/d:accept/deny • e:expand • s:split • f:toggle filter • c/C:toggle/only comments • r/R:toggle/only reviews • l/L:toggle/only line comments • Ctrl+c:resolve all • Enter:process • q:cancel"))
 
 	return b.String()
 }

--- a/ui/pr_review.go
+++ b/ui/pr_review.go
@@ -188,7 +188,7 @@ func (m PRReviewModel) Update(msg tea.Msg) (PRReviewModel, tea.Cmd) {
 			m = m.resetViewAfterFilterChange()
 			return m, nil
 
-		case "ctrl+c":
+		case "ctrl+r":
 			// Request confirmation before resolving all conversations
 			return m, func() tea.Msg { return PRRequestResolveConfirmationMsg{} }
 


### PR DESCRIPTION
This pull request introduces a feature to resolve all unresolved review threads in a GitHub pull request (PR) through the application's user interface. It includes new commands, user prompts, error handling, and integration with the GitHub CLI for fetching and resolving threads. Additionally, it improves logging and state management to ensure a smooth user experience.

### New Feature: Resolve All PR Conversations
* **Added command to resolve all unresolved review threads**: Introduced `resolveAllPRConversations` function and `resolveConversationsMsg` type to handle the resolution of review threads using the GitHub CLI and GraphQL API. [[1]](diffhunk://#diff-6798adbdeafaeecb0b2618b1e68ba4cb9f69b4e486dbd5dbc0e4eea5de0611b6R202-R295) [[2]](diffhunk://#diff-ac523602cb95ad8ab5f71ce7762b01ff1c7f388d1acd3edb9d4cb6d8bd89ac32R814-R958)
* **Confirmation dialog for resolving threads**: Added a confirmation overlay (`overlay.NewConfirmationOverlay`) to prompt users before resolving all threads. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R334-R393) [[2]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R1405-R1464)
* **New keybinding**: Introduced `ctrl+r` as the keybinding to trigger the "resolve all PR conversations" feature. [[1]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR24) [[2]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR113) [[3]](diffhunk://#diff-afc783802cd8fd9fdcbfcd151232a4edeea3c7e7620b1633239feb287d9ee3fbR258-R261)

### UI and State Management Enhancements
* **Improved state transitions**: Ensured proper state handling when overlays are nil or actions are confirmed, including returning to the appropriate state after resolving threads. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7L876-R998) [[2]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R1015-R1022) [[3]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R2075-R2085)
* **Error and success message handling**: Updated the UI to display detailed success or error messages after attempting to resolve threads, with logs added to an error log for debugging. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R662-R720) [[2]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7R2243-R2248)

### GitHub CLI Integration
* **Fetching unresolved threads**: Added `GetUnresolvedThreads` method to retrieve unresolved review threads using a GraphQL query.
* **Resolving threads**: Added `ResolveThread` method to resolve individual threads via a GraphQL mutation.
* **Enhanced error handling**: Improved error messages for common GitHub CLI issues, such as authentication errors or missing PRs.

### Keybindings and Help Updates
* **Help menu update**: Documented the new `ctrl+r` keybinding in the help menu for resolving all PR conversations.

These changes collectively enhance the application's functionality for managing PR conversations, providing users with a streamlined and reliable way to resolve all unresolved threads directly from the interface.